### PR TITLE
PR: FIX for [ Issue#2 | BUG: Change default start date when creating a commons to be today's date ]

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -70,7 +70,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     
     const testid = "CommonsForm";
     const curr = new Date();
-    const today = curr.toISOString().split('T')[0];
+    const today = curr.toISOString().split('T')[0].substring(0,8) + curr.toString().split(' ')[2];;
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {


### PR DESCRIPTION
## Overview
In this PR, we made changes to CommonForms.js so that the default commons start date reflects the current day of the local time zone rather than UTC time.

## Validation
To check if the local time is correct, please check after 5:00pm PST because at this point UTC time is at 00:00 and rolls over to the next day. The time should still reflect the current day rather than the next day.
https://project-ok-at-computers-dev.dokku-06.cs.ucsb.edu/

## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #2 
