### PR TITLE
Updating Profits Table

### DIFF
--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -1,10 +1,55 @@
 import React from "react";
+//import Pagination from 'react-bootstrap/Pagination'
 import OurTable from "main/components/OurTable";
+import { Button } from "react-bootstrap";
+import { useBackend } from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
 
-export default function ProfitsTable({ profits }) {
+
+const ProfitsTable = () => {
+
+    const testId = "ProfitsTable";
+    const refreshJobsIntervalMilliseconds = 2000;
+
+    const [selectedPage, setSelectedPage] = React.useState(0);
+
+    const PROFIT_PAGE_SIZE = 5;
+    const { commonsId } = useParams();
     
-    // Stryker disable ArrayDeclaration : [columns] and [students] are performance optimization; mutation preserves correctness
-    const memoizedColumns = React.useMemo(() => 
+    // Stryker disable all
+    const {
+        data: page
+    } = useBackend(
+        ["/api/profits/paged"],
+        {
+            method: "GET",
+            url: "/api/profits/paged/commonsid", 
+            params: {
+                commonsId: commonsId,
+                pageNumber: selectedPage,
+                pageSize: PROFIT_PAGE_SIZE,
+            }
+        },
+        {content: [], totalPages: 0},
+        { refetchInterval: refreshJobsIntervalMilliseconds }
+    );
+    // Stryker restore  all
+
+    const testid = "ProfitsTable";
+
+    const previousPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage - 1);
+        }
+    }
+
+    const nextPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage + 1);
+        }
+    }
+
+    const columns = 
         [
             {
                 Header: "Profit",
@@ -12,24 +57,46 @@ export default function ProfitsTable({ profits }) {
             },
             {
                 Header: "Date",
-                accessor: "date",
+                accessor: "timestamp",
+                Cell: ({ value }) => new Date(value).toLocaleDateString(),
             },
             {
                 Header: "Health",
-                accessor: (row) => `${row.avgCowHealth + '%'}`
+                accessor: (row) => `${row.avgCowHealth.toFixed(2) + '%'}`
             },
             {
                 Header: "Cows",
                 accessor: "numCows",
             },
-        ], 
-    []);
-    const memoizedDates = React.useMemo(() => profits, [profits]);
-    // Stryker restore ArrayDeclaration
+        ];
+    
 
-    return <OurTable
-        data={memoizedDates}
-        columns={memoizedColumns}
-        testid={"ProfitsTable"}
-    />;
-};
+    const sortees = React.useMemo(
+        () => [
+            {
+                id: "timestamp",
+                desc: true
+            }
+        ],
+        // Stryker disable next-line all
+        []
+    );
+
+
+    return (
+        <>
+            <p>Page: {selectedPage + 1}</p>
+            <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
+            <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
+            < OurTable
+                data={page.content}
+                columns={columns}
+                testid={testid}
+                initialState={{ sortBy: sortees }}
+                
+            />
+        </>
+    );
+}; 
+
+export default ProfitsTable;

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -1,5 +1,4 @@
 import React from "react";
-//import Pagination from 'react-bootstrap/Pagination'
 import OurTable from "main/components/OurTable";
 import { Button } from "react-bootstrap";
 import { useBackend } from "main/utils/useBackend";


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I changed the profits table on the play page to mimic that of the jobs table in the manage jobs tab. The table now shows PROFIT_PAGE_SIZE items, where PROFIT_PAGE_SIZE is a variable that can be changed. Next and Previous buttons allow for the access of old profit records. The code in this PR DOES NOT address the issue where new profit records are added to page 1. I fix that issue in another PR as I had to change the previous backend code to solve this problem.
## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="292" alt="Screenshot 2024-05-20 131726" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/129905805/52141ee0-504a-4da9-8f97-5b041c3b1cf4">



## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->
https://happycows-sawyerrice-dev.dokku-06.cs.ucsb.edu/
Closes #10 
