### PR TITLE
(3/3) Frontend Leave Button to Home Page

### DIFF
--- a/frontend/src/main/components/Commons/CommonsCard.js
+++ b/frontend/src/main/components/Commons/CommonsCard.js
@@ -24,7 +24,7 @@ function isFutureDate(startingDate) {
     }
 }
 
-const CommonsCard = ({ buttonText, buttonLink, commons }) => {
+const CommonsCard = ({ buttonText, buttonLink, commons, leaveButtonLink}) => {
     const testIdPrefix = "commonsCard";
     return (
         <Card.Body style={
@@ -36,11 +36,11 @@ const CommonsCard = ({ buttonText, buttonLink, commons }) => {
                     <Col sx={4} data-testid={`${testIdPrefix}-id-${commons.id}`}>{commons.id}</Col>
                     <Col sx={4} data-testid={`${testIdPrefix}-name-${commons.id}`}>{commons.name}</Col>
                     {buttonText != null &&
-                        <Col sm={4}>
+                        <Col sm={4} className="d-flex justify-content-end">
                             <Button
                                 data-testid={`${testIdPrefix}-button-${buttonText}-${commons.id}`}
                                 size="sm"
-                                className="mx-4"
+                                className="mx-2"
                                 onClick={() => {
                                     if (buttonText === "Join" && isFutureDate(commons.startingDate)) {
                                         // Stryker disable next-line all: unable to read alert text in tests
@@ -50,6 +50,16 @@ const CommonsCard = ({ buttonText, buttonLink, commons }) => {
                                     }
                                     }} >{buttonText}
                             </Button>
+                            {buttonText === "Visit" && (
+                            <Button
+                                data-testid={`${testIdPrefix}-button-leave-${commons.id}`}
+                                size="sm"
+                                className="mx-2"
+                                onClick={() => leaveButtonLink(commons.id)}
+                            >
+                                Leave
+                            </Button>
+                        )}
                         </Col>
                     }
                 </Row>

--- a/frontend/src/main/components/Commons/CommonsList.js
+++ b/frontend/src/main/components/Commons/CommonsList.js
@@ -36,7 +36,7 @@ const CommonsList = (props) => {
                 </Card.Subtitle>
                 {
                     props.commonList.map(
-                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} />)
+                        (c) => (<CommonsCard key={c.id} commons={c} buttonText={props.buttonText} buttonLink={props.buttonLink} leaveButtonLink={props.leaveButtonLink} />)
                     )
                 }
             </React.Fragment> 

--- a/frontend/src/main/pages/HomePage.js
+++ b/frontend/src/main/pages/HomePage.js
@@ -59,6 +59,7 @@ export default function HomePage({hour=null}) {
 
   let navigate = useNavigate();
   const visitButtonClick = (id) => { navigate("/play/" + id) };
+  const leaveButtonClick = null;
 
   //create a list of commons that the user hasn't joined for use in the "Join a New Commons" list.
   const commonsNotJoinedList = commonsNotJoined(commons, commonsJoined);
@@ -73,7 +74,7 @@ export default function HomePage({hour=null}) {
       </Card>
         <Container>
           <Row>
-            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} /></Col>
+            <Col sm><CommonsList commonList={commonsJoined} title="Visit A Commons" buttonText={"Visit"} buttonLink={visitButtonClick} leaveButtonLink={leaveButtonClick} /></Col>
             <Col sm><CommonsList commonList={commonsNotJoinedList} title="Join A New Commons" buttonText={"Join"} buttonLink={mutation.mutate} /></Col>
           </Row>
         </Container>

--- a/frontend/src/tests/components/Commons/CommonsCard.test.js
+++ b/frontend/src/tests/components/Commons/CommonsCard.test.js
@@ -155,4 +155,18 @@ describe("CommonsCard tests", () => {
         fireEvent.click(button);
         expect(click).toBeCalledTimes(1);
     });
+
+    test("leave button click calls leaveButtonLink with commons id", () => {
+        const click = jest.fn();    
+        render(
+            <CommonsCard commons={commonsFixtures.threeCommons[0]} buttonText={"Visit"} leaveButtonLink={click} />
+        );
+    
+        const leaveButton = screen.getByTestId("commonsCard-button-leave-5");
+        expect(leaveButton).toBeInTheDocument();
+        expect(typeof (leaveButton.textContent)).toBe('string');
+        expect(leaveButton.textContent).toEqual('Leave');
+        fireEvent.click(leaveButton);
+        expect(click).toBeCalledTimes(1);
+    });
 });


### PR DESCRIPTION
## Overview
In this PR, I created a frontend leave button implemented in the Home page. To do this I added a variable leaveButtonLink to the CommonCard class, that is only shown when the button is visit (instead of join). Next, when the CommonsList function is called in the Common List, I input the props.leaveButtonLink. Then, when the CommonsList is called in HomePage.js, I input a leaveButtonLink value null, as I will implement the backend next. To fix the coverage test, I added a test to CommonCard.test.js to account for when the leaveButton is clicked. 

## Screenshot
<img width="536" alt="Screenshot 2024-05-21 at 1 18 25 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/24783417/b9af7fef-99e6-416c-a2d4-e4f4b806df10">


## Feedback Request
<!--Anywhere specific you want reviewers to take a look at and give suggestions. Delete if not needed.-->
Please give suggestions on the following:
Do you think that this will cause problems if the CommonCard is called in any other instance? I looked but there could be some function call that I am not accounting for. 

## Future Possibilities
<!--What do you think this project could become? Delete if not needed.-->
Some possible points could be:
- This is the beginning part of adding the leave button functionality for a common. Next I have to connect the backend. 

## Validation
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Look To See If Leave button is on the home page

## Tests
- [x] Frontend Unit tests (`npm test`) pass
- [x] Frontend Test coverage (`npm run coverage`) 100%
- [x] Frontend Mutation tests (`npx stryker run`) 100% 
- [x] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #15 #18 