### PR TITLE
PR: [BUG] Fix CommonsController delete that does not allow deleting user with associated profit table

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/CommonsController.java
@@ -11,6 +11,7 @@ import edu.ucsb.cs156.happiercows.models.CreateCommonsParams;
 import edu.ucsb.cs156.happiercows.models.HealthUpdateStrategyList;
 import edu.ucsb.cs156.happiercows.repositories.CommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
+import edu.ucsb.cs156.happiercows.repositories.ProfitRepository;
 import edu.ucsb.cs156.happiercows.strategies.CowHealthUpdateStrategies;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
@@ -22,6 +23,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.transaction.annotation.Transactional;
 import edu.ucsb.cs156.happiercows.services.CommonsPlusBuilderService;
 
 
@@ -38,6 +40,9 @@ public class CommonsController extends ApiController {
 
     @Autowired
     private UserCommonsRepository userCommonsRepository;
+
+    @Autowired
+    private ProfitRepository profitRepository;
 
     @Autowired
     ObjectMapper mapper;
@@ -336,6 +341,7 @@ public class CommonsController extends ApiController {
     @Operation(summary="Delete a user from a commons")
     @PreAuthorize("hasRole('ROLE_ADMIN')")
     @DeleteMapping("/{commonsId}/users/{userId}")
+    @Transactional
     public Object deleteUserFromCommon(@PathVariable("commonsId") Long commonsId,
                                        @PathVariable("userId") Long userId) throws Exception {
 
@@ -343,6 +349,8 @@ public class CommonsController extends ApiController {
                 .orElseThrow(() -> new EntityNotFoundException(
                         UserCommons.class, "commonsId", commonsId, "userId", userId)
                 );
+
+        profitRepository.deleteByUserCommons(userCommons);
 
         userCommonsRepository.delete(userCommons);
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ProfitRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ProfitRepository.java
@@ -8,6 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProfitRepository extends CrudRepository<Profit, Long> {
     Iterable<Profit> findAllByUserCommons(UserCommons userCommons);
-    void deleteByUserCommons(UserCommons userCommons); // Add this line
+    void deleteByUserCommons(UserCommons userCommons);
 
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/repositories/ProfitRepository.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/repositories/ProfitRepository.java
@@ -8,4 +8,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ProfitRepository extends CrudRepository<Profit, Long> {
     Iterable<Profit> findAllByUserCommons(UserCommons userCommons);
+    void deleteByUserCommons(UserCommons userCommons); // Add this line
+
 }


### PR DESCRIPTION
## Overview
In this PR, I fixed a bug that would throw an error when attempting to call the: 

CommonsController:  @Operation(summary="Delete a user from a commons")

The problem was due to a dependent table associated with the user in the Profit section, that would not delete.  To fix this I added deleteByUserCommons to the ProfitRepository, and called the function inside the CommonsController delete user function. I additionally had to add a @Transactional header, import the transactional annotation, and Autowired the profitRepository. 

## Screenshots

BUG:
<img width="1139" alt="Screenshot 2024-05-21 at 3 03 08 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/89555340/49c0e9ea-126e-4291-8fcc-64845bb57058">

FIX: 
<img width="615" alt="Screenshot 2024-05-21 at 2 59 49 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/24783417/567ac650-89d5-4415-8e98-80bf06ee6b3a">


## Feedback Request
- Let me know if this fix looks good? 
- Also need to make sure that when the Profits are deleted, everything on the profit side is handled okay.


## Validation 
1. Download this branch.
2. Run the project.
3. Go to this page.
4. Test this function in Swagger. 
5. Make sure the Profit section works well after the fix. 

## Tests
<!--Add any additional tests or required tests-->
- [x] Backend Unit tests (`mvn test`) pass
- [x] Backend Test coverage (`mvn test jacoco:report`) 100%
- [x] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 


## Linked Issues
<!--Issues related to the PR-->
Closes #26
