### PR TITLE
Adding Frontend Pagination to Profits Table

### DIFF
--- a/frontend/src/fixtures/pagedProfitsFixtures.js
+++ b/frontend/src/fixtures/pagedProfitsFixtures.js
@@ -1,0 +1,191 @@
+const pagedProfitsFixtures = {
+    emptyPage: {
+        "content": [],
+        "pageable": {
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "offset": 0,
+            "pageNumber": 0,
+            "pageSize": 5,
+            "paged": true,
+            "unpaged": false
+        },
+        "totalPages": 0,
+        "totalElements": 0,
+        "last": true,
+        "size": 5,
+        "number": 0,
+        "sort": {
+            "empty": false,
+            "unsorted": false,
+            "sorted": true
+        },
+        "numberOfElements": 0,
+        "first": true,
+        "empty": true
+    },
+    onePage:
+    {
+        "content": [
+            {
+                "amount": 120,
+                "timestamp": "2023-05-16T20:55:00.04076",
+                "numCows": 6,
+                "avgCowHealth": 91,
+                
+            },
+            {
+                "amount": 115,
+                "timestamp": "2023-05-17T20:38:00.04076",
+                "numCows": 4,
+                "avgCowHealth": 94,
+            },
+            
+        ],
+        "pageable": {
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "offset": 0,
+            "pageNumber": 0,
+            "pageSize": 5,
+            "paged": true,
+            "unpaged": false
+        },
+        "totalPages": 1,
+        "totalElements": 2,
+        "last": true,
+        "size": 5,
+        "number": 0,
+        "sort": {
+            "empty": false,
+            "unsorted": false,
+            "sorted": true
+        },
+        "numberOfElements": 2,
+        "first": true,
+        "empty": false
+    },
+    twoPages: [
+        {
+            "content": [
+                {
+                    "amount": 10,
+                    "timestamp": "2026-04-11T20:55:00.04076",
+                    "numCows": 3,
+                    "avgCowHealth": 72,
+                },
+                {
+                    "amount": 1,
+                    "timestamp": "2025-03-12T20:55:00.04076",
+                    "numCows": 9,
+                    "avgCowHealth": 91,
+                },
+                {
+                    "amount": 10,
+                    "timestamp": "2024-10-20T20:55:00.04076",
+                    "numCows": 2,
+                    "avgCowHealth": 50,
+                },
+                {
+                    "amount": 18,
+                    "timestamp": "2023-03-03T20:55:00.04076",
+                    "numCows": 8,
+                    "avgCowHealth": 34,
+                },
+                {
+                    "amount": 120,
+                    "timestamp": "2022-05-16T20:55:00.04076",
+                    "numCows": 6,
+                    "avgCowHealth": 78,
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 0,
+                "pageNumber": 0,
+                "pageSize": 5,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 2,
+            "totalElements": 9,
+            "last": false,
+            "size": 5,
+            "number": 0,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 5,
+            "first": true,
+            "empty": false
+        },
+        {
+            "content": [
+                {
+                    "amount": 5,
+                    "timestamp": "2021-02-06T20:55:00.04076",
+                    "numCows": 8,
+                    "avgCowHealth": 56,
+                },
+                {
+                    "amount": 908,
+                    "timestamp": "2020-12-01T20:55:00.04076",
+                    "numCows": 9,
+                    "avgCowHealth": 89,
+                },
+                {
+                    "amount": 19,
+                    "timestamp": "2019-02-16T20:55:00.04076",
+                    "numCows": 11,
+                    "avgCowHealth": 91,
+                },
+                {
+                    "amount": 14,
+                    "timestamp": "1967-05-18T20:55:00.04076",
+                    "numCows": 7,
+                    "avgCowHealth": 99,
+                }
+            ],
+            "pageable": {
+                "sort": {
+                    "empty": false,
+                    "unsorted": false,
+                    "sorted": true
+                },
+                "offset": 5,
+                "pageNumber": 1,
+                "pageSize": 5,
+                "paged": true,
+                "unpaged": false
+            },
+            "totalPages": 2,
+            "totalElements": 9,
+            "last": true,
+            "size": 5,
+            "number": 1,
+            "sort": {
+                "empty": false,
+                "unsorted": false,
+                "sorted": true
+            },
+            "numberOfElements": 4,
+            "first": false,
+            "empty": false
+        }
+    ]
+    
+};
+
+export default pagedProfitsFixtures;

--- a/frontend/src/main/components/Commons/PagedProfitsTable.js
+++ b/frontend/src/main/components/Commons/PagedProfitsTable.js
@@ -1,0 +1,104 @@
+import React from "react";
+import OurTable from "main/components/OurTable";
+import { Button } from "react-bootstrap";
+import { useBackend } from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
+import { timestampToDate } from "main/utils/dateUtils";
+
+
+const PagedProfitsTable = () => {
+
+    const testId = "PagedProfitsTable";
+    const refreshJobsIntervalMilliseconds = 5000;
+
+    const [selectedPage, setSelectedPage] = React.useState(0);
+
+    const PROFIT_PAGE_SIZE = 5;
+    const { commonsId } = useParams();
+    
+    // Stryker disable all
+    const {
+        data: page
+    } = useBackend(
+        ["/api/profits/paged/commonsid"],
+        {
+            method: "GET",
+            url: "/api/profits/paged/commonsid", 
+            params: {
+                commonsId: commonsId,
+                pageNumber: selectedPage,
+                pageSize: PROFIT_PAGE_SIZE,
+            }
+        },
+        {content: [], totalPages: 0},
+        { refetchInterval: refreshJobsIntervalMilliseconds }
+    );
+    // Stryker restore  all
+
+    const testid = "PagedProfitsTable";
+
+    const previousPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage - 1);
+        }
+    }
+
+    const nextPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage + 1);
+        }
+    }
+
+    const columns = 
+        [
+            {
+                Header: "Profit",
+                accessor: "amount",
+                Cell: ({value}) => `$${value.toFixed(2)}`,
+            },
+            {
+                Header: "Date",
+                accessor: "timestamp",
+                Cell: ({ value }) => timestampToDate(value),
+            },
+            {
+                Header: "Health",
+                accessor: "avgCowHealth",
+                Cell: ({value}) => `${value.toFixed(2) + '%'}`
+            },
+            {
+                Header: "Cows",
+                accessor: "numCows",
+            },
+        ];
+    
+
+    const sortees = React.useMemo(
+        () => [
+            {
+                id: "timestamp",
+                desc: true
+            }
+        ],
+        // Stryker disable next-line all
+        []
+    );
+
+
+    return (
+        <>
+            <p>Page: {selectedPage + 1}</p>
+            <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
+            <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
+            < OurTable
+                data={page.content}
+                columns={columns}
+                testid={testid}
+                initialState={{ sortBy: sortees }}
+                
+            />
+        </>
+    );
+}; 
+
+export default PagedProfitsTable;

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -2,19 +2,9 @@ import React from "react";
 import { Card } from "react-bootstrap";
 import PagedProfitsTable from "main/components/Commons/PagedProfitsTable";
 
-//import { timestampToDate } from "main/utils/dateUtils";
 
-
-const Profits = (/* { profits } */) => {
-    /* const profitsForTable =
-        profits ?
-        profits.map(profit => ({
-            date: timestampToDate(profit.timestamp),
-            ...profit
-        })) : 
-        // Stryker disable next-line ArrayDeclaration : no need to test what happens if [] is replaced with ["Stryker was here"]
-        [];
-        profitsForTable.reverse(); */
+const Profits = () => {
+    
     return (
         <Card>
             <Card.Header as="h5">
@@ -25,7 +15,7 @@ const Profits = (/* { profits } */) => {
                 <Card.Title>
                     You will earn profits from milking your cows everyday at 4am.
                 </Card.Title>
-                <PagedProfitsTable /*profits={profitsForTable}*/ />
+                <PagedProfitsTable  />
             </Card.Body>
         </Card>
     );

--- a/frontend/src/main/components/Commons/Profits.js
+++ b/frontend/src/main/components/Commons/Profits.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { Card } from "react-bootstrap";
-import ProfitsTable from "main/components/Commons/ProfitsTable";
+import PagedProfitsTable from "main/components/Commons/PagedProfitsTable";
 
-import { timestampToDate } from "main/utils/dateUtils";
+//import { timestampToDate } from "main/utils/dateUtils";
 
 
-const Profits = ({ profits }) => {
-    const profitsForTable =
+const Profits = (/* { profits } */) => {
+    /* const profitsForTable =
         profits ?
         profits.map(profit => ({
             date: timestampToDate(profit.timestamp),
@@ -14,7 +14,7 @@ const Profits = ({ profits }) => {
         })) : 
         // Stryker disable next-line ArrayDeclaration : no need to test what happens if [] is replaced with ["Stryker was here"]
         [];
-        profitsForTable.reverse();
+        profitsForTable.reverse(); */
     return (
         <Card>
             <Card.Header as="h5">
@@ -25,7 +25,7 @@ const Profits = ({ profits }) => {
                 <Card.Title>
                     You will earn profits from milking your cows everyday at 4am.
                 </Card.Title>
-                <ProfitsTable profits={profitsForTable} />
+                <PagedProfitsTable /*profits={profitsForTable}*/ />
             </Card.Body>
         </Card>
     );

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -1,10 +1,54 @@
 import React from "react";
 import OurTable from "main/components/OurTable";
+import { Button } from "react-bootstrap";
+import { useBackend } from "main/utils/useBackend";
+import { useParams } from "react-router-dom";
 
-export default function ProfitsTable({ profits }) {
+
+const ProfitsTable = () => {
+
+    const testId = "ProfitsTable";
+    const refreshJobsIntervalMilliseconds = 2000;
+
+    const [selectedPage, setSelectedPage] = React.useState(0);
+
+    const PROFIT_PAGE_SIZE = 5;
+    const { commonsId } = useParams();
     
-    // Stryker disable ArrayDeclaration : [columns] and [students] are performance optimization; mutation preserves correctness
-    const memoizedColumns = React.useMemo(() => 
+    // Stryker disable all
+    const {
+        data: page
+    } = useBackend(
+        ["/api/profits/paged"],
+        {
+            method: "GET",
+            url: "/api/profits/paged/commonsid", 
+            params: {
+                commonsId: commonsId,
+                pageNumber: selectedPage,
+                pageSize: PROFIT_PAGE_SIZE,
+            }
+        },
+        {content: [], totalPages: 0},
+        { refetchInterval: refreshJobsIntervalMilliseconds }
+    );
+    // Stryker restore  all
+
+    const testid = "ProfitsTable";
+
+    const previousPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage - 1);
+        }
+    }
+
+    const nextPageCallback = () => {
+        return () => {
+            setSelectedPage(selectedPage + 1);
+        }
+    }
+
+    const columns = 
         [
             {
                 Header: "Profit",
@@ -12,24 +56,46 @@ export default function ProfitsTable({ profits }) {
             },
             {
                 Header: "Date",
-                accessor: "date",
+                accessor: "timestamp",
+                Cell: ({ value }) => new Date(value).toLocaleDateString(),
             },
             {
                 Header: "Health",
-                accessor: (row) => `${row.avgCowHealth + '%'}`
+                accessor: (row) => `${row.avgCowHealth.toFixed(2) + '%'}`
             },
             {
                 Header: "Cows",
                 accessor: "numCows",
             },
-        ], 
-    []);
-    const memoizedDates = React.useMemo(() => profits, [profits]);
-    // Stryker restore ArrayDeclaration
+        ];
+    
 
-    return <OurTable
-        data={memoizedDates}
-        columns={memoizedColumns}
-        testid={"ProfitsTable"}
-    />;
-};
+    const sortees = React.useMemo(
+        () => [
+            {
+                id: "timestamp",
+                desc: true
+            }
+        ],
+        // Stryker disable next-line all
+        []
+    );
+
+
+    return (
+        <>
+            <p>Page: {selectedPage + 1}</p>
+            <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
+            <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
+            < OurTable
+                data={page.content}
+                columns={columns}
+                testid={testid}
+                initialState={{ sortBy: sortees }}
+                
+            />
+        </>
+    );
+}; 
+
+export default ProfitsTable;

--- a/frontend/src/main/components/Commons/ProfitsTable.js
+++ b/frontend/src/main/components/Commons/ProfitsTable.js
@@ -1,54 +1,10 @@
 import React from "react";
 import OurTable from "main/components/OurTable";
-import { Button } from "react-bootstrap";
-import { useBackend } from "main/utils/useBackend";
-import { useParams } from "react-router-dom";
 
-
-const ProfitsTable = () => {
-
-    const testId = "ProfitsTable";
-    const refreshJobsIntervalMilliseconds = 2000;
-
-    const [selectedPage, setSelectedPage] = React.useState(0);
-
-    const PROFIT_PAGE_SIZE = 5;
-    const { commonsId } = useParams();
+export default function ProfitsTable({ profits }) {
     
-    // Stryker disable all
-    const {
-        data: page
-    } = useBackend(
-        ["/api/profits/paged"],
-        {
-            method: "GET",
-            url: "/api/profits/paged/commonsid", 
-            params: {
-                commonsId: commonsId,
-                pageNumber: selectedPage,
-                pageSize: PROFIT_PAGE_SIZE,
-            }
-        },
-        {content: [], totalPages: 0},
-        { refetchInterval: refreshJobsIntervalMilliseconds }
-    );
-    // Stryker restore  all
-
-    const testid = "ProfitsTable";
-
-    const previousPageCallback = () => {
-        return () => {
-            setSelectedPage(selectedPage - 1);
-        }
-    }
-
-    const nextPageCallback = () => {
-        return () => {
-            setSelectedPage(selectedPage + 1);
-        }
-    }
-
-    const columns = 
+    // Stryker disable ArrayDeclaration : [columns] and [students] are performance optimization; mutation preserves correctness
+    const memoizedColumns = React.useMemo(() => 
         [
             {
                 Header: "Profit",
@@ -56,46 +12,24 @@ const ProfitsTable = () => {
             },
             {
                 Header: "Date",
-                accessor: "timestamp",
-                Cell: ({ value }) => new Date(value).toLocaleDateString(),
+                accessor: "date",
             },
             {
                 Header: "Health",
-                accessor: (row) => `${row.avgCowHealth.toFixed(2) + '%'}`
+                accessor: (row) => `${row.avgCowHealth + '%'}`
             },
             {
                 Header: "Cows",
                 accessor: "numCows",
             },
-        ];
-    
+        ], 
+    []);
+    const memoizedDates = React.useMemo(() => profits, [profits]);
+    // Stryker restore ArrayDeclaration
 
-    const sortees = React.useMemo(
-        () => [
-            {
-                id: "timestamp",
-                desc: true
-            }
-        ],
-        // Stryker disable next-line all
-        []
-    );
-
-
-    return (
-        <>
-            <p>Page: {selectedPage + 1}</p>
-            <Button data-testid={`${testId}-previous-button`}onClick={previousPageCallback()} disabled={ selectedPage === 0}>Previous</Button>
-            <Button data-testid={`${testId}-next-button`} onClick={nextPageCallback()} disabled={page.totalPages===0 || selectedPage === page.totalPages-1}>Next</Button>
-            < OurTable
-                data={page.content}
-                columns={columns}
-                testid={testid}
-                initialState={{ sortBy: sortees }}
-                
-            />
-        </>
-    );
-}; 
-
-export default ProfitsTable;
+    return <OurTable
+        data={memoizedDates}
+        columns={memoizedColumns}
+        testid={"ProfitsTable"}
+    />;
+};

--- a/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
+++ b/frontend/src/tests/components/Commons/PagedProfitsTable.test.js
@@ -1,42 +1,48 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
-import PagedJobsTable from "main/components/Jobs/PagedJobsTable";
-import pagedJobsFixtures from "fixtures/pagedJobsFixtures";
+
+import PagedProfitsTable from "main/components/Commons/PagedProfitsTable";
+
+import pagedProfitsFixtures from "fixtures/pagedProfitsFixtures";
+
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PagedJobsTable tests", () => {
+describe("PagedProfitsTable tests", () => {
+    
   const queryClient = new QueryClient();
 
   const axiosMock = new AxiosMockAdapter(axios);
 
-  const testId = "PagedJobsTable";
+  const testId = "PagedProfitsTable";
 
   beforeEach(() => {
     axiosMock.reset();
     axiosMock.resetHistory();
   });
 
+
+
   test("renders correct content", async () => {
 
     // arrange
 
-    axiosMock.onGet("/api/jobs/all/pageable").reply(200, pagedJobsFixtures.onePage);
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.onePage);
 
     // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <PagedJobsTable />
+          <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
     // assert
-    const expectedHeaders = ['id', 'Created', 'Updated', 'Status', 'Log'];
-    const expectedFields = ['id', 'Created', 'Updated', 'status', 'Log'];
+    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
+    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -52,26 +58,23 @@ describe("PagedJobsTable tests", () => {
       expect(header).toBeInTheDocument();
     });
 
-    expect(axiosMock.history.get[0].url).toBe("/api/jobs/all/pageable");
-    expect(axiosMock.history.get[0].params).toEqual({ page: 0, size: 10 });
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+    expect(axiosMock.history.get[0].params).toEqual({commonsId: undefined, pageNumber: 0, pageSize: 5 });
 
-    expect(screen.getByTestId(`${testId}-cell-row-0-col-id`)).toHaveTextContent(
-      "1"
-    );
+    expect(screen.getByTestId(`${testId}-cell-row-0-col-amount`)).toHaveTextContent(
+      "120");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Created`)
-    ).toHaveTextContent("8/8/2023, 12:14:00");
+      screen.getByTestId(`${testId}-cell-row-0-col-timestamp`)
+    ).toHaveTextContent("2023-05-16");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Updated`)
-    ).toHaveTextContent("8/8/2023, 12:14:00");
+      screen.getByTestId(`${testId}-cell-row-0-col-avgCowHealth`)
+    ).toHaveTextContent("91.00%");
     expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-status`)
-    ).toHaveTextContent("complete");
-    expect(
-      screen.getByTestId(`${testId}-cell-row-0-col-Log`)
-    ).toHaveTextContent(`Updating cow health...Commons Blue, degradationRate: 0.1, carryingCapacity: 10User: Phill Conrad, numCows: 3, cowHealth: 100.0 old cow health: 100.0, new cow health: 100.0User: Phillip Conrad, numCows: 7, cowHealth: 100.0 old cow health: 100.0, new cow health: 100.0Commons Red, degradationRate: 0.1, carryingCapacity: 2User: Phill Conrad, numCows: 10, cowHealth: 54.40000000000016 old cow health: 54.40000000000016, new cow health: 53.600000000000165Cow health has been updated!`);
-
-    expect(screen.getByTestId(`${testId}-header-id-sort-carets`)).toHaveTextContent("🔽");
+      screen.getByTestId(`${testId}-cell-row-0-col-numCows`)
+    ).toHaveTextContent("6");
+    
+      
+    expect(screen.getByTestId(`${testId}-header-timestamp-sort-carets`)).toHaveTextContent("🔽");
 
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
@@ -83,17 +86,17 @@ describe("PagedJobsTable tests", () => {
     expect(previousButton).toBeDisabled();
   });
 
-  test("buttons are disabled where there are zero pages", async () => {
+   test("buttons are disabled where there are zero pages", async () => {
 
     // arrange
 
-    axiosMock.onGet("/api/jobs/all/pageable").reply(200, pagedJobsFixtures.emptyPage);
+    axiosMock.onGet("/api/profits/paged/commonsid").reply(200, pagedProfitsFixtures.emptyPage);
 
     // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <PagedJobsTable />
+          <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
 
@@ -103,8 +106,8 @@ describe("PagedJobsTable tests", () => {
       expect(axiosMock.history.get.length).toBe(1);
     });
 
-    expect(axiosMock.history.get[0].url).toBe("/api/jobs/all/pageable");
-    expect(axiosMock.history.get[0].params).toEqual({ page: 0, size: 10 });
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId:undefined, pageNumber: 0, pageSize: 5 });
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -113,30 +116,32 @@ describe("PagedJobsTable tests", () => {
     const previousButton = screen.getByTestId(`${testId}-previous-button`);
     expect(previousButton).toBeInTheDocument();
     expect(previousButton).toBeDisabled();
-  });
+  }); 
+
+
+
 
 
   test("renders correct content with multiple pages", async () => {
     // arrange
 
-    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 0, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[0]);
-    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 1, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[1]);
-    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 2, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[2]);
-    axiosMock.onGet("/api/jobs/all/pageable",  { params: { page: 3, size: 10 } }).reply(200, pagedJobsFixtures.fourPages[3]);
+    axiosMock.onGet("/api/profits/paged/commonsid"   ,{ params: {commonsId: undefined, pageNumber: 0, pageSize: 5 } }   ).reply(200, pagedProfitsFixtures.twoPages[0]);
+    axiosMock.onGet("/api/profits/paged/commonsid" ,{ params: {commonsId: undefined, pageNumber: 1, pageSize: 5 } }     ).reply(200, pagedProfitsFixtures.twoPages[1]);
+    
 
     // act
     render(
       <QueryClientProvider client={queryClient}>
         <MemoryRouter>
-          <PagedJobsTable />
+          <PagedProfitsTable />
         </MemoryRouter>
       </QueryClientProvider>
 
     );
 
     // assert
-    const expectedHeaders = ['id', 'Created', 'Updated', 'Status', 'Log'];
-    const expectedFields = ['id', 'Created', 'Updated', 'status', 'Log'];
+    const expectedHeaders = ['Profit', 'Date', 'Health', 'Cows'];
+    const expectedFields = ['amount', 'timestamp', 'avgCowHealth', 'numCows'];
 
     expectedHeaders.forEach((headerText) => {
       const header = screen.getByText(headerText);
@@ -147,13 +152,17 @@ describe("PagedJobsTable tests", () => {
       expect(axiosMock.history.get.length).toBe(1);
     });
 
+    
+
     expectedFields.forEach((field) => {
       const header = screen.getByTestId(`${testId}-cell-row-0-col-${field}`);
       expect(header).toBeInTheDocument();
     });
 
-    expect(axiosMock.history.get[0].url).toBe("/api/jobs/all/pageable");
-    expect(axiosMock.history.get[0].params).toEqual({ page: 0, size: 10 });
+    expect(axiosMock.history.get[0].url).toBe("/api/profits/paged/commonsid");
+    expect(axiosMock.history.get[0].params).toEqual({ commonsId: undefined, pageNumber: 0, pageSize: 5 });
+
+    
 
     const nextButton = screen.getByTestId(`${testId}-next-button`);
     expect(nextButton).toBeInTheDocument();
@@ -165,30 +174,31 @@ describe("PagedJobsTable tests", () => {
     expect(nextButton).toBeEnabled();
 
     expect(screen.getByText(`Page: 1`)).toBeInTheDocument();
+
+    expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+      ).toHaveTextContent("10");
+
     fireEvent.click(nextButton);
+
 
     await waitFor(() => {expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
     expect(previousButton).toBeEnabled();
-    expect(nextButton).toBeEnabled();
+    expect(nextButton).toBeDisabled();
 
-    
 
     fireEvent.click(previousButton);
     await waitFor(() => { expect(screen.getByText(`Page: 1`)).toBeInTheDocument();});
     expect(previousButton).toBeDisabled();
-    expect(nextButton).toBeEnabled();
+    expect(nextButton).toBeEnabled(); 
 
-    fireEvent.click(nextButton);
-    await waitFor(() => { expect(screen.getByText(`Page: 2`)).toBeInTheDocument();});
+     expect(
+        screen.getByTestId(`${testId}-cell-row-0-col-amount`)
+      ).toHaveTextContent("10"); 
+    
+    
 
-    fireEvent.click(nextButton);
-    await waitFor(() => { expect(screen.getByText(`Page: 3`)).toBeInTheDocument();});
-
-    fireEvent.click(nextButton);
-    await waitFor(() => { expect(screen.getByText(`Page: 4`)).toBeInTheDocument();});
-    expect(previousButton).toBeEnabled();
-    expect(nextButton).toBeDisabled();
   });
 
-});
-
+    
+    });

--- a/frontend/src/tests/components/Commons/Profits.test.js
+++ b/frontend/src/tests/components/Commons/Profits.test.js
@@ -1,7 +1,7 @@
 import { render, screen, waitFor } from "@testing-library/react";
 import Profits from "main/components/Commons/Profits"; 
 import userCommonsFixtures from "fixtures/userCommonsFixtures"; 
-import profitsFixtures from "fixtures/profitsFixtures";
+
 import { QueryClient, QueryClientProvider } from "react-query";
 
 describe("Profits tests", () => {

--- a/frontend/src/tests/components/Commons/Profits.test.js
+++ b/frontend/src/tests/components/Commons/Profits.test.js
@@ -5,12 +5,7 @@ import userCommonsFixtures from "fixtures/userCommonsFixtures";
 import { QueryClient, QueryClientProvider } from "react-query";
 
 describe("Profits tests", () => {
-    /* test("renders properly for empty profits array", () => {
-        render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={[]} />
-        );
-    });
- */
+    
     test("renders properly when profits is not given", async () => {
         const queryClient = new QueryClient();
         render(
@@ -24,28 +19,5 @@ describe("Profits tests", () => {
         });
     });
 
-    /* test("renders properly when profits is non-empty", async () => {
-         render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={profitsFixtures.threeProfits} />
-        );
-
-        //const queryClient = new QueryClient(); // Create a new QueryClient instance
-           
-        expect(await screen.findByTestId("ProfitsTable-cell-row-0-col-Profit")).toBeInTheDocument();
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-Profit")).toHaveTextContent(/52.80/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-Profit")).toHaveTextContent(/54.60/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-Profit")).toHaveTextContent(/58.20/);
-
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-timestamp")).toHaveTextContent(/2023-05-17/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-timestamp")).toHaveTextContent(/2023-05-16/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-timestamp")).toHaveTextContent(/2023-05-15/);
-
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-Health")).toHaveTextContent(/88%/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-Health")).toHaveTextContent(/91%/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-Health")).toHaveTextContent(/97%/);
-
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-numCows")).toHaveTextContent(/6/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-numCows")).toHaveTextContent(/6/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-numCows")).toHaveTextContent(/6/);
-    }); */
+    
 });

--- a/frontend/src/tests/components/Commons/Profits.test.js
+++ b/frontend/src/tests/components/Commons/Profits.test.js
@@ -2,36 +2,43 @@ import { render, screen, waitFor } from "@testing-library/react";
 import Profits from "main/components/Commons/Profits"; 
 import userCommonsFixtures from "fixtures/userCommonsFixtures"; 
 import profitsFixtures from "fixtures/profitsFixtures";
+import { QueryClient, QueryClientProvider } from "react-query";
 
 describe("Profits tests", () => {
-    test("renders properly for empty profits array", () => {
+    /* test("renders properly for empty profits array", () => {
         render(
             <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={[]} />
         );
     });
-
-    test("renders properly when profits is not defined", async () => {
+ */
+    test("renders properly when profits is not given", async () => {
+        const queryClient = new QueryClient();
         render(
-            <Profits userCommons={userCommonsFixtures.oneUserCommons[0]}  />
+        <QueryClientProvider client={queryClient}>
+                <Profits userCommons={userCommonsFixtures.oneUserCommons[0]}  />
+        </QueryClientProvider>
+            
         );
         await waitFor(()=>{
-            expect(screen.getByTestId("ProfitsTable-header-Profit") ).toBeInTheDocument();
+            expect(screen.getByTestId("PagedProfitsTable-header-amount") ).toBeInTheDocument();
         });
     });
 
-    test("renders properly when profits is non-empty", async () => {
-        render(
+    /* test("renders properly when profits is non-empty", async () => {
+         render(
             <Profits userCommons={userCommonsFixtures.oneUserCommons[0]} profits={profitsFixtures.threeProfits} />
         );
+
+        //const queryClient = new QueryClient(); // Create a new QueryClient instance
            
         expect(await screen.findByTestId("ProfitsTable-cell-row-0-col-Profit")).toBeInTheDocument();
         expect(screen.getByTestId("ProfitsTable-cell-row-0-col-Profit")).toHaveTextContent(/52.80/);
         expect(screen.getByTestId("ProfitsTable-cell-row-1-col-Profit")).toHaveTextContent(/54.60/);
         expect(screen.getByTestId("ProfitsTable-cell-row-2-col-Profit")).toHaveTextContent(/58.20/);
 
-        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-date")).toHaveTextContent(/2023-05-17/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-date")).toHaveTextContent(/2023-05-16/);
-        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-date")).toHaveTextContent(/2023-05-15/);
+        expect(screen.getByTestId("ProfitsTable-cell-row-0-col-timestamp")).toHaveTextContent(/2023-05-17/);
+        expect(screen.getByTestId("ProfitsTable-cell-row-1-col-timestamp")).toHaveTextContent(/2023-05-16/);
+        expect(screen.getByTestId("ProfitsTable-cell-row-2-col-timestamp")).toHaveTextContent(/2023-05-15/);
 
         expect(screen.getByTestId("ProfitsTable-cell-row-0-col-Health")).toHaveTextContent(/88%/);
         expect(screen.getByTestId("ProfitsTable-cell-row-1-col-Health")).toHaveTextContent(/91%/);
@@ -40,5 +47,5 @@ describe("Profits tests", () => {
         expect(screen.getByTestId("ProfitsTable-cell-row-0-col-numCows")).toHaveTextContent(/6/);
         expect(screen.getByTestId("ProfitsTable-cell-row-1-col-numCows")).toHaveTextContent(/6/);
         expect(screen.getByTestId("ProfitsTable-cell-row-2-col-numCows")).toHaveTextContent(/6/);
-    });
+    }); */
 });

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -11,7 +11,6 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -23,9 +22,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import java.util.Collections;
-import java.util.Comparator;
 
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
@@ -94,12 +90,7 @@ public class ProfitsController extends ApiController {
 
         int start = pageNumber * pageSize;
         int end = Math.min((start + pageSize), allProfits.size());
-
-        allProfits.sort(Comparator.comparing(Profit::getTimestamp).reversed());
-
         List<Profit> paginatedProfits = allProfits.subList(start, end);
-
-        
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Page<Profit> profitsPage = new PageImpl<>(paginatedProfits, pageable, allProfits.size());

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/ProfitsController.java
@@ -11,6 +11,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -22,6 +23,9 @@ import org.springframework.web.bind.annotation.RestController;
 
 import java.util.ArrayList;
 import java.util.List;
+
+import java.util.Collections;
+import java.util.Comparator;
 
 @Tag(name = "Profits")
 @RequestMapping("/api/profits")
@@ -90,7 +94,12 @@ public class ProfitsController extends ApiController {
 
         int start = pageNumber * pageSize;
         int end = Math.min((start + pageSize), allProfits.size());
+
+        allProfits.sort(Comparator.comparing(Profit::getTimestamp).reversed());
+
         List<Profit> paginatedProfits = allProfits.subList(start, end);
+
+        
 
         Pageable pageable = PageRequest.of(pageNumber, pageSize);
         Page<Profit> profitsPage = new PageImpl<>(paginatedProfits, pageable, allProfits.size());


### PR DESCRIPTION
## Overview
<!--A paragraph of the PR and related content-->
In this PR, I changed the profits table on the play page to mimic that of the jobs table in the manage jobs tab. The table now shows PROFIT_PAGE_SIZE items, where PROFIT_PAGE_SIZE is a variable that can be changed. Next and Previous buttons allow for the access of old profit records. The code in this PR DOES NOT address the issue where new profit records are added to page 1. I fix that issue in another PR as I had to change the previous backend code to solve this problem. Tests were also added for the new PagedProfitsTable.
## Screenshots (Optional)
<!--Necessary screenshots and any necessary captions here. Delete if not needed.-->
<img width="292" alt="Screenshot 2024-05-20 131726" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/129905805/52141ee0-504a-4da9-8f97-5b041c3b1cf4">



## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
<!--Issues related to the PR-->


