### PR TITLE
PR: FIX: [BUG: Disallow ability to navigate to unjoined commons]

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -15,6 +15,8 @@ import Background from "../../assets/PlayPageBackground.jpg";
 import ChatPanel from "main/components/Chat/ChatPanel";
 import ManageCowsModal from "main/components/Commons/ManageCowsModal";
 
+//import { useNavigate } from "react-router-dom";
+
 export default function PlayPage() {
     const { commonsId } = useParams();
     const { data: currentUser } = useCurrentUser();
@@ -149,6 +151,8 @@ export default function PlayPage() {
         fontFamily: "Arial, sans-serif",
         fontSize: "30px",
     };
+    
+    //let navigate = useNavigate();
 
     return (
         <div
@@ -160,13 +164,17 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {!!currentUser && <CommonsPlay currentUser={currentUser} />}
+
+                    {(!(typeof commonsPlus == 'undefined') && (currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }
+                    
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}
                             currentUser={currentUser}
                         />
                     )}
+                    
                     <br />
                     {!!userCommons && !!commonsPlus && (
                         <CardGroup>

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -162,8 +162,8 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {(!(typeof commonsPlus == 'undefined') && (currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) && !!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
+                    {(!(typeof commonsPlus == 'undefined') && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id))) && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -150,9 +150,7 @@ export default function PlayPage() {
         fontSize: "30px",
     };
     
-    const commonsLoaded = !(typeof commonsPlus == 'undefined')
-    const userJoinedCommons = commonsLoaded && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
-    const userNotJoinedCommons = commonsLoaded && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
+
 
     return (
         <div
@@ -164,8 +162,8 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {userJoinedCommons && !!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {userNotJoinedCommons &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
+                    {(!(typeof commonsPlus == 'undefined') && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id))) && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -150,7 +150,9 @@ export default function PlayPage() {
         fontSize: "30px",
     };
     
-
+    const commonsLoaded = !(typeof commonsPlus == 'undefined')
+    const userJoinedCommons = commonsLoaded && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
+    const userNotJoinedCommons = commonsLoaded && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
 
     return (
         <div
@@ -162,8 +164,8 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {(!(typeof commonsPlus == 'undefined') && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id))) && !!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
+                    {userJoinedCommons && !!currentUser && <CommonsPlay currentUser={currentUser} />}
+                    {userNotJoinedCommons &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -15,8 +15,6 @@ import Background from "../../assets/PlayPageBackground.jpg";
 import ChatPanel from "main/components/Chat/ChatPanel";
 import ManageCowsModal from "main/components/Commons/ManageCowsModal";
 
-//import { useNavigate } from "react-router-dom";
-
 export default function PlayPage() {
     const { commonsId } = useParams();
     const { data: currentUser } = useCurrentUser();
@@ -152,7 +150,7 @@ export default function PlayPage() {
         fontSize: "30px",
     };
     
-    //let navigate = useNavigate();
+
 
     return (
         <div
@@ -164,17 +162,14 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-
                     {(!(typeof commonsPlus == 'undefined') && (currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) && !!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }
-                    
+                    {(!(typeof commonsPlus == 'undefined') && !(currentUser.root.user.commons.some(com => com.id == commonsPlus.commons.id))) &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}
                             currentUser={currentUser}
                         />
                     )}
-                    
                     <br />
                     {!!userCommons && !!commonsPlus && (
                         <CardGroup>

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -39,7 +39,7 @@ describe("CommonsOverview tests", () => {
     });
 
     test("Redirects to the LeaderboardPage for an admin when you click visit", async () => {
-        apiCurrentUserFixtures.adminUser.user.commons = commonsFixtures.oneCommons[0];
+        apiCurrentUserFixtures.adminUser.user.commons[0] = commonsFixtures.oneCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.adminUser);
         axiosMock.onGet("/api/commons/plus", {params: {id:1}}).reply(200, commonsPlusFixtures.oneCommonsPlus[0]);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);
@@ -68,7 +68,7 @@ describe("CommonsOverview tests", () => {
             ...commonsPlusFixtures.oneCommonsPlus,
             commons : ourCommons
         }
-        apiCurrentUserFixtures.userOnly.user.commonsPlus = commonsPlusFixtures.oneCommonsPlus[0];
+        apiCurrentUserFixtures.userOnly.user.commons[0] = ourCommons;
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/commons/plus", {params: {id:1}}).reply(200, ourCommonsPlus);
         axiosMock.onGet("/api/leaderboard/all").reply(200, leaderboardFixtures.threeUserCommonsLB);

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -8,6 +8,10 @@ import PlayPage from "main/pages/PlayPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
+import commonsFixtures from "fixtures/commonsFixtures"; 
+import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
+import NotJoinedPage from "main/pages/NotJoinedPage";
+
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
     useParams: () => ({
@@ -343,4 +347,103 @@ describe("PlayPage tests", () => {
             expect(screen.getByTestId("playpage-chat-toggle")).toBeInTheDocument();
         });
     })
+    
+    test("not joined test", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        
+        axiosMock.onGet("/api/currentUser").reply(200, {
+       
+        user: {
+            id : 1,
+            fullName : "Nom Guerre",
+            givenName : "Nom",
+            familyName : "Guerre",
+            emailVerified : true,
+            admin : false,
+            commons : [
+                {
+                    id : 2,
+                    name : "TestCommons",
+                },
+                {
+                    id : 3,
+                    name : "OtherTestCommons",
+                }
+            ]
+        
+        
+        }});
+
+        axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
+            id: 5,
+            name: "Sample Commons"
+        });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();
+            expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+        });
+    })
+    
+       test("joined test", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        
+        axiosMock.onGet("/api/currentUser").reply(200, {
+       
+        user: {
+            id : 1,
+            fullName : "Nom Guerre",
+            givenName : "Nom",
+            familyName : "Guerre",
+            emailVerified : true,
+            admin : false,
+            commons : [
+                {
+                    id : 1,
+                    name : "TestCommons",
+                },
+                {
+                    id : 3,
+                    name : "OtherTestCommons",
+                }
+            ]
+        
+        
+        }});
+
+        axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
+            id: 5,
+            name: "Sample Commons"
+        });
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+            expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+            expect(screen.queryByText("Announcements")).toBeInTheDocument();
+        });
+    })
+    
+   
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -388,8 +388,10 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => {
             expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();
-            expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+            
         });
+      
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
     })
     
        test("joined test", async () => {
@@ -436,9 +438,11 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => {
             expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
-            expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-            expect(screen.queryByText("Announcements")).toBeInTheDocument();
         });
+        
+        expect(screen.queryByTestId("commons-card")).toBeInTheDocument();
+        expect(screen.queryByText("Announcements")).toBeInTheDocument();
+        
     })
     
    

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -344,48 +344,7 @@ describe("PlayPage tests", () => {
         });
     })
     
-    test("user has not joined the commons (single commons joined)", async () => {
-        
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        
-        axiosMock.onGet("/api/currentUser").reply(200, {
-       
-        user: {
-            id : 1,
-            fullName : "Nom Guerre",
-            givenName : "Nom",
-            familyName : "Guerre",
-            emailVerified : true,
-            admin : false,
-            commons : [
-                {
-                    id : 2,
-                    name : "TestCommons",
-                }
-            ]
-        
-        }});
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlayPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();    
-        });
-
-        expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
-        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
-
-    })
-    
-    test("user has not joined the commons (multiple commons joined)", async () => {
+    test("not joined test", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -410,8 +369,14 @@ describe("PlayPage tests", () => {
                     name : "OtherTestCommons",
                 }
             ]
-           
+        
+        
         }});
+
+        axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
+            id: 5,
+            name: "Sample Commons"
+        });
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -422,15 +387,15 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();    
+            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument(); 
+            expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
         });
+      
+      	
 
-        expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
-        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
-	
     })
     
-    test("user has joined the commons (single commons joined)", async () => {
+       test("joined test", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -449,60 +414,20 @@ describe("PlayPage tests", () => {
                 {
                     id : 1,
                     name : "TestCommons",
-                }
-            ]
-        
-        }});
-
-        render(
-            <QueryClientProvider client={queryClient}>
-                <MemoryRouter>
-                    <PlayPage />
-                </MemoryRouter>
-            </QueryClientProvider>
-        );
-
-        await waitFor(() => {
-            expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-
-        });
-        
-        await waitFor(() => {
-            expect(screen.getByText("Announcements")).toBeInTheDocument();
-        });        
-        
-        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
-        
-    })
-
-    test("user has joined the commons (multiple commons joined)", async () => {
-        
-        axiosMock.reset();
-        axiosMock.resetHistory();
-        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-        
-        axiosMock.onGet("/api/currentUser").reply(200, {
-       
-        user: {
-            id : 1,
-            fullName : "Nom Guerre",
-            givenName : "Nom",
-            familyName : "Guerre",
-            emailVerified : true,
-            admin : false,
-            commons : [
-                {
-                    id : 1,
-                    name : "TestCommons"
                 },
                 {
                     id : 3,
-                    name : "OtherTestCommons"
+                    name : "OtherTestCommons",
                 }
             ]
-
+        
+        
         }});
+
+        axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
+            id: 5,
+            name: "Sample Commons"
+        });
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -513,17 +438,14 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
+            expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
             expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
         });
         
-        await waitFor(() => {
-            expect(screen.getByText("Announcements")).toBeInTheDocument();
-        });        
-        
-        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+
         
     })
-
+    
    
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -344,7 +344,48 @@ describe("PlayPage tests", () => {
         });
     })
     
-    test("not joined test", async () => {
+    test("user has not joined the commons (single commons joined)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        
+        axiosMock.onGet("/api/currentUser").reply(200, {
+       
+        user: {
+            id : 1,
+            fullName : "Nom Guerre",
+            givenName : "Nom",
+            familyName : "Guerre",
+            emailVerified : true,
+            admin : false,
+            commons : [
+                {
+                    id : 2,
+                    name : "TestCommons",
+                }
+            ]
+        
+        }});
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();    
+        });
+
+        expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
+
+    })
+    
+    test("user has not joined the commons (multiple commons joined)", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -369,14 +410,8 @@ describe("PlayPage tests", () => {
                     name : "OtherTestCommons",
                 }
             ]
-        
-        
+           
         }});
-
-        axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
-            id: 5,
-            name: "Sample Commons"
-        });
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -387,15 +422,15 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument(); 
-            expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
+            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();    
         });
-      
-      	
 
+        expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
+        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
+	
     })
     
-       test("joined test", async () => {
+    test("user has joined the commons (single commons joined)", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -414,20 +449,10 @@ describe("PlayPage tests", () => {
                 {
                     id : 1,
                     name : "TestCommons",
-                },
-                {
-                    id : 3,
-                    name : "OtherTestCommons",
                 }
             ]
         
-        
         }});
-
-        axiosMock.onGet("/api/commons", { params: { id: 5 } }).reply(200, {
-            id: 5,
-            name: "Sample Commons"
-        });
 
         render(
             <QueryClientProvider client={queryClient}>
@@ -438,14 +463,67 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
             expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-            expect(screen.getByText("Announcements")).toBeInTheDocument();
+
         });
         
-
+        await waitFor(() => {
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
+        });        
+        
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
         
     })
-    
+
+    test("user has joined the commons (multiple commons joined)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        
+        axiosMock.onGet("/api/currentUser").reply(200, {
+       
+        user: {
+            id : 1,
+            fullName : "Nom Guerre",
+            givenName : "Nom",
+            familyName : "Guerre",
+            emailVerified : true,
+            admin : false,
+            commons : [
+                {
+                    id : 1,
+                    name : "TestCommons"
+                },
+                {
+                    id : 3,
+                    name : "OtherTestCommons"
+                }
+            ]
+
+        }});
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+        });
+        
+        await waitFor(() => {
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
+        });        
+        
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        
+    })
+
    
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -440,8 +440,8 @@ describe("PlayPage tests", () => {
             expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
         });
         
-        expect(screen.queryByTestId("commons-card")).toBeInTheDocument();
-        expect(screen.queryByText("Announcements")).toBeInTheDocument();
+        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+        expect(screen.getByText("Announcements")).toBeInTheDocument();
         
     })
     

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -387,11 +387,12 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();
-            
+            expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument(); 
+            expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
         });
       
-        expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();
+      	
+
     })
     
        test("joined test", async () => {
@@ -438,10 +439,11 @@ describe("PlayPage tests", () => {
 
         await waitFor(() => {
             expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+            expect(screen.getByTestId("commons-card")).toBeInTheDocument();
+            expect(screen.getByText("Announcements")).toBeInTheDocument();
         });
         
-        expect(screen.getByTestId("commons-card")).toBeInTheDocument();
-        expect(screen.getByText("Announcements")).toBeInTheDocument();
+
         
     })
     

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -10,7 +10,6 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
 import commonsFixtures from "fixtures/commonsFixtures"; 
 import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
-import NotJoinedPage from "main/pages/NotJoinedPage";
 
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -8,9 +8,6 @@ import PlayPage from "main/pages/PlayPage";
 import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
 import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 
-import commonsFixtures from "fixtures/commonsFixtures"; 
-import commonsPlusFixtures from "fixtures/commonsPlusFixtures";
-
 jest.mock("react-router-dom", () => ({
     ...jest.requireActual("react-router-dom"),
     useParams: () => ({


### PR DESCRIPTION
## Overview
In this PR, we make changes to the PlayPage.js so that when a user enters a commons they are not a member of, a message shows up indicating this fact.

Outside of PlayPage.js, changes were made to the CommonsOverview test for compatibility (managing an array of user joined commons). A new series of tests was also added to the PlayPage test.

## Screenshots (Optional)
![proj-notjoined-fix](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/165851243/a46b8083-7a9b-411c-9c0d-f87a107481cd)

## Feedback Request (Optional)
The back end error messages still show up and are a bit unsightly. If anyone has any suggestions to suppress them that would be great!

## Future Possibilities (Optional)
This page could be spruced up to look more nicer. We could also add buttons to go back to the main menu (instead of having to rely on the browser back button) or to even join the commons.

## Validation (Optional)
Go to the test dokku, login, and enter "/play/#" after the URL (eg: https://project-ok-at-computers-dev.dokku-06.cs.ucsb.edu/play/#) where the # is the id number of a commons you have not joined. The commons numbers and joined status can be seen on the home page. A message should appear telling the user they have not joined this commons.
https://project-ok-at-computers-dev.dokku-06.cs.ucsb.edu/

## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #5
