### PR TITLE
PR: FIX: [BUG: Starting date fix still has issue with month and year.]

### DIFF
--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -69,7 +69,9 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     // Stryker restore all
     
     const testid = "CommonsForm";
+    // Stryker disable all
     const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
+    // Stryker restore all
     const today = curr.toISOString().split('T')[0]
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -3,6 +3,7 @@ import {useForm} from "react-hook-form";
 import {useBackend} from "main/utils/useBackend";
 import { useEffect } from "react";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
+import {getTodayCurrMonthNextMonth} from "main/utils/dateUtils";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     let modifiedCommons = initialCommons ? { ...initialCommons } : {};  // make a shallow copy of initialCommons
@@ -69,12 +70,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     // Stryker restore all
     
     const testid = "CommonsForm";
-    // Stryker disable all
-    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
-    // Stryker restore all
-    const today = curr.toISOString().split('T')[0]
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
     const DefaultVals = {
         name: "",
         startingBalance: defaultValuesData?.startingBalance || "10000",

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -69,8 +69,8 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     // Stryker restore all
     
     const testid = "CommonsForm";
-    const curr = new Date();
-    const today = curr.toISOString().split('T')[0].substring(0,8) + curr.toString().split(' ')[2];;
+    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
+    const today = curr.toISOString().split('T')[0]
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {

--- a/frontend/src/main/components/Commons/CommonsForm.js
+++ b/frontend/src/main/components/Commons/CommonsForm.js
@@ -3,7 +3,7 @@ import {useForm} from "react-hook-form";
 import {useBackend} from "main/utils/useBackend";
 import { useEffect } from "react";
 import HealthUpdateStrategiesDropdown from "main/components/Commons/HealthStrategiesUpdateDropdown";
-import {getTodayCurrMonthNextMonth} from "main/utils/dateUtils";
+import {getTodayNextMonth} from "main/utils/dateUtils";
 
 function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     let modifiedCommons = initialCommons ? { ...initialCommons } : {};  // make a shallow copy of initialCommons
@@ -70,7 +70,7 @@ function CommonsForm({initialCommons, submitAction, buttonLabel = "Create"}) {
     // Stryker restore all
     
     const testid = "CommonsForm";
-    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
+    const {today, nextMonth} = getTodayNextMonth();
     const DefaultVals = {
         name: "",
         startingBalance: defaultValuesData?.startingBalance || "10000",

--- a/frontend/src/main/utils/dateUtils.js
+++ b/frontend/src/main/utils/dateUtils.js
@@ -18,6 +18,14 @@ const hourInSeconds = 60 * minutesInSeconds;
 const dayInSeconds = 24 * hourInSeconds;
 const weekInSeconds = 7 * dayInSeconds;
 
+const getTodayCurrMonthNextMonth = () => {
+    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000);
+    const today = curr.toISOString().split('T')[0];
+    const currMonth = curr.getMonth() % 12;
+    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    return { today, currMonth, nextMonth };
+}
+
 export function formatTime(timeString) {
     if (!timeString) {
         return "";
@@ -49,4 +57,4 @@ export function formatTime(timeString) {
     return dateFromEpoch.toLocaleDateString();
 }
 
-export {timestampToDate, padWithZero, daysSinceTimestamp};
+export {timestampToDate, padWithZero, daysSinceTimestamp, getTodayCurrMonthNextMonth};

--- a/frontend/src/main/utils/dateUtils.js
+++ b/frontend/src/main/utils/dateUtils.js
@@ -18,12 +18,12 @@ const hourInSeconds = 60 * minutesInSeconds;
 const dayInSeconds = 24 * hourInSeconds;
 const weekInSeconds = 7 * dayInSeconds;
 
-const getTodayCurrMonthNextMonth = () => {
+const getTodayNextMonth = () => {
     const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000);
     const today = curr.toISOString().split('T')[0];
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
-    return { today, currMonth, nextMonth };
+    return { today, nextMonth };
 }
 
 export function formatTime(timeString) {
@@ -57,4 +57,4 @@ export function formatTime(timeString) {
     return dateFromEpoch.toLocaleDateString();
 }
 
-export {timestampToDate, padWithZero, daysSinceTimestamp, getTodayCurrMonthNextMonth};
+export {timestampToDate, padWithZero, daysSinceTimestamp, getTodayNextMonth};

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -6,6 +6,7 @@ import commonsFixtures from "fixtures/commonsFixtures"
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import healthUpdateStrategyListFixtures from "fixtures/healthUpdateStrategyListFixtures";
+import {getTodayCurrMonthNextMonth} from "main/utils/dateUtils";
 
 // Next line uses technique from https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
 import * as useBackendModule from "main/utils/useBackend";
@@ -153,10 +154,7 @@ describe("CommonsForm tests", () => {
 
   it("Check Default Values and correct styles", async () => {
 
-    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
-    const today = curr.toISOString().split('T')[0]
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth
@@ -287,10 +285,7 @@ describe("CommonsForm tests", () => {
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
-    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
-    const today = curr.toISOString().split('T')[0]
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth, aboveCapacityStrategy: "Linear", belowCapacityStrategy: "Constant"
@@ -359,10 +354,7 @@ test("the correct parameters are passed to useBackend", async () => {
 
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
-    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
-    const today = curr.toISOString().split('T')[0]
-    const currMonth = curr.getMonth() % 12;
-    const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
+    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
     const defaultValuesData = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -6,7 +6,7 @@ import commonsFixtures from "fixtures/commonsFixtures"
 import AxiosMockAdapter from "axios-mock-adapter";
 import axios from "axios";
 import healthUpdateStrategyListFixtures from "fixtures/healthUpdateStrategyListFixtures";
-import {getTodayCurrMonthNextMonth} from "main/utils/dateUtils";
+import {getTodayNextMonth} from "main/utils/dateUtils";
 
 // Next line uses technique from https://www.chakshunyu.com/blog/how-to-spy-on-a-named-import-in-jest/
 import * as useBackendModule from "main/utils/useBackend";
@@ -154,7 +154,7 @@ describe("CommonsForm tests", () => {
 
   it("Check Default Values and correct styles", async () => {
 
-    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
+    const {today, nextMonth} = getTodayNextMonth();
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth
@@ -285,7 +285,7 @@ describe("CommonsForm tests", () => {
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
-    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
+    const {today, nextMonth} = getTodayNextMonth();
     const DefaultVals = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth, aboveCapacityStrategy: "Linear", belowCapacityStrategy: "Constant"
@@ -354,7 +354,7 @@ test("the correct parameters are passed to useBackend", async () => {
 
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
-    const {today, currMonth, nextMonth} = getTodayCurrMonthNextMonth();
+    const {today, nextMonth} = getTodayNextMonth();
     const defaultValuesData = {
       name: "", startingBalance: 10000, cowPrice: 100,
       milkPrice: 1, degradationRate: 0.001, carryingCapacity: 100, startingDate: today, lastDate: nextMonth

--- a/frontend/src/tests/components/Commons/CommonsForm.test.js
+++ b/frontend/src/tests/components/Commons/CommonsForm.test.js
@@ -153,8 +153,8 @@ describe("CommonsForm tests", () => {
 
   it("Check Default Values and correct styles", async () => {
 
-    const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
+    const today = curr.toISOString().split('T')[0]
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {
@@ -287,8 +287,8 @@ describe("CommonsForm tests", () => {
   });
 
   it("renders correctly when an initialCommons is not passed in", async () => {
-    const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
+    const today = curr.toISOString().split('T')[0]
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const DefaultVals = {
@@ -359,8 +359,8 @@ test("the correct parameters are passed to useBackend", async () => {
 
   test("populates form fields with default values when initialCommons is not provided", async () => {
 
-    const curr = new Date();
-    const today = curr.toISOString().substr(0, 10);
+    const curr = new Date(Date.now()-(new Date()).getTimezoneOffset()*60000)
+    const today = curr.toISOString().split('T')[0]
     const currMonth = curr.getMonth() % 12;
     const nextMonth = new Date(curr.getFullYear(), currMonth + 1, curr.getDate()).toISOString().substr(0, 10);
     const defaultValuesData = {

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -1,4 +1,4 @@
-import { padWithZero, timestampToDate, daysSinceTimestamp, formatTime, getTodayCurrMonthNextMonth } from "main/utils/dateUtils";
+import { padWithZero, timestampToDate, daysSinceTimestamp, formatTime, getTodayNextMonth } from "main/utils/dateUtils";
 
 
 describe("dateUtils tests", () => {
@@ -73,10 +73,10 @@ describe("dateUtils tests", () => {
     });
   })
   
-  describe("getTodayCurrMonthNextMonth tests", () => {
+  describe("getTodayNextMonth tests", () => {
     it("calculates days properly", () => {
       jest.useFakeTimers().setSystemTime(new Date('2022-06-01T18:00'));
-      const { today, currMonth, nextMonth } = getTodayCurrMonthNextMonth();
+      const { today, nextMonth } = getTodayNextMonth();
       expect(today).toBe('2022-06-01');
     });
   });

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -71,13 +71,18 @@ describe("dateUtils tests", () => {
       const twoWeeksAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
       expect(formatTime(twoWeeksAgo.toISOString())).toEqual(twoWeeksAgo.toLocaleDateString());
     });
-  })
+  });
   
   describe("getTodayNextMonth tests", () => {
-    it("calculates days properly", () => {
+    it("calculates date properly", () => {
       jest.useFakeTimers().setSystemTime(new Date('2022-06-01T18:00'));
       const { today, nextMonth } = getTodayNextMonth();
       expect(today).toBe('2022-06-01');
+    });
+    it("calculates next month properly", () => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-06-01T18:00'));
+      const { today, nextMonth } = getTodayNextMonth();
+      expect(nextMonth).toBe('2022-07-01');
     });
   });
   

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -1,4 +1,4 @@
-import { padWithZero, timestampToDate, daysSinceTimestamp, formatTime } from "main/utils/dateUtils";
+import { padWithZero, timestampToDate, daysSinceTimestamp, formatTime, getTodayCurrMonthNextMonth } from "main/utils/dateUtils";
 
 
 describe("dateUtils tests", () => {
@@ -72,4 +72,13 @@ describe("dateUtils tests", () => {
       expect(formatTime(twoWeeksAgo.toISOString())).toEqual(twoWeeksAgo.toLocaleDateString());
     });
   })
+  
+  describe("getTodayCurrMonthNextMonth tests", () => {
+    it("calculates days properly", () => {
+      jest.useFakeTimers().setSystemTime(new Date('2022-06-01T18:00'));
+      const { today, currMonth, nextMonth } = getTodayCurrMonthNextMonth();
+      expect(today).toBe('2022-06-01');
+    });
+  });
+  
 });

--- a/frontend/src/tests/utils/dateUtils.test.js
+++ b/frontend/src/tests/utils/dateUtils.test.js
@@ -74,14 +74,10 @@ describe("dateUtils tests", () => {
   });
   
   describe("getTodayNextMonth tests", () => {
-    it("calculates date properly", () => {
+    it("calculates date and next month properly", () => {
       jest.useFakeTimers().setSystemTime(new Date('2022-06-01T18:00'));
       const { today, nextMonth } = getTodayNextMonth();
       expect(today).toBe('2022-06-01');
-    });
-    it("calculates next month properly", () => {
-      jest.useFakeTimers().setSystemTime(new Date('2022-06-01T18:00'));
-      const { today, nextMonth } = getTodayNextMonth();
       expect(nextMonth).toBe('2022-07-01');
     });
   });


### PR DESCRIPTION
## Overview
In this PR, we make some corrections to the previous PR #19 which only partially fixed the incorrect start date problem. Those issues have now been corrected in this PR.

Time getting operation code has been moved from `CommonsForm.js` and placed in a single function `getTodayNextMonth()` found in `dateUtils.js`.

~~There is a portion of the fix where I had to turn off stryker. The reason for this is because the bug is time sensitive and the mutation in question is arithmetic (multiplication to division). If the bug is not visible (before 5:00pm PST) this mutation test would fail because the offset factor whether correct (large due to multiplication) or wrong (small due to division) would not change the date.  After 5:00pm, the mutation test will pass. For this reason, I have disabled stryker for this portion.~~

Time testing was available in the `dateUtils` test file so mutation testing is performed on the date getting code.

## Validation (Optional)
To check if the local time is correct, please check after 5:00pm PST because at this point UTC time is at 00:00 and rolls over to the next day. The time should still reflect the current day rather than the next day.

To check day roll over at the end of the month, you may need to set your system clock to 5:00pm PST and set your system calendar to to end of the month. Or wait until the end of month and then wait until 5:00pm PST.

https://project-ok-at-computers-dev.dokku-06.cs.ucsb.edu/

## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #32 
