### PR TITLE
B2: Add endpoints that suspend or restore user (MERGE AFTER B1)

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/UsersController.java
@@ -1,7 +1,10 @@
 package edu.ucsb.cs156.happiercows.controllers;
+import edu.ucsb.cs156.happiercows.errors.EntityNotFoundException;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.Optional;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
@@ -9,11 +12,14 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import edu.ucsb.cs156.happiercows.entities.User;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 
 @Tag(name="User information (admin only)")
 @RequestMapping("/api/admin/users")
@@ -33,5 +39,29 @@ public class UsersController extends ApiController {
         Iterable<User> users = userRepository.findAll();
         String body = mapper.writeValueAsString(users);
         return ResponseEntity.ok().body(body);
+    }
+
+    @Operation(summary = "Suspend a user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/suspend")
+    public Object suspendUser(@Parameter(name = "userid", description = "Long, user ID of user to suspend", example = "1", required = true) @RequestParam Long userid) {
+        User user = userRepository.findById(userid)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, userid));
+
+        user.setSuspended(true);
+        userRepository.save(user);
+        return genericMessage("User with id %s has been suspended".formatted(userid));
+    }
+
+    @Operation(summary = "Restore a user by id")
+    @PreAuthorize("hasRole('ROLE_ADMIN')")
+    @PostMapping("/restore")
+    public Object restoreUser(@Parameter(name = "userid", description = "Long, user ID of user to restore", example = "1", required = true) @RequestParam Long userid) {
+        User user = userRepository.findById(userid)
+                .orElseThrow(() -> new EntityNotFoundException(User.class, userid));
+
+        user.setSuspended(false);
+        userRepository.save(user);
+        return genericMessage("User with id %s has been restored".formatted(userid));
     }
 }

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -31,7 +31,7 @@ public class User {
   private Instant lastOnline = Instant.now();
 
   @Builder.Default
-  private boolean suspended = false;
+  private Boolean suspended = false;
 
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons", 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/User.java
@@ -30,6 +30,9 @@ public class User {
   @Builder.Default
   private Instant lastOnline = Instant.now();
 
+  @Builder.Default
+  private boolean suspended = false;
+
   @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.PERSIST,CascadeType.REMOVE})
   @JoinTable(name = "user_commons", 
     joinColumns = @JoinColumn(name = "user_id", referencedColumnName = "id"), 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/UsersControllerTests.java
@@ -1,5 +1,6 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -15,14 +16,19 @@ import edu.ucsb.cs156.happiercows.testconfig.TestConfig;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Map;
+import java.util.Optional;
 
 @WebMvcTest(controllers = UsersController.class)
 @Import(TestConfig.class)
@@ -31,6 +37,17 @@ public class UsersControllerTests extends ControllerTestCase {
 
   @MockBean
   UserRepository userRepository;
+
+  private User user;
+
+  @BeforeEach
+  public void setUp() {
+      user = User.builder()
+              .id(1L)
+              .email("test@example.com")
+              .suspended(false)
+              .build();
+  }
 
   @Test
   public void users__logged_out() throws Exception {
@@ -73,5 +90,78 @@ public class UsersControllerTests extends ControllerTestCase {
     String responseString = response.getResponse().getContentAsString();
     assertEquals(expectedJson, responseString);
 
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testSuspendUser_success() throws Exception {
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/suspend")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      verify(userRepository, times(1)).save(user);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 has been suspended", json.get("message"));
+      assertEquals(true, user.getSuspended());
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testSuspendUser_notFound() throws Exception {
+      when(userRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/suspend")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isNotFound())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 not found", json.get("message"));
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testRestoreUser_success() throws Exception {
+      user.setSuspended(true);
+      when(userRepository.findById(1L)).thenReturn(Optional.of(user));
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/restore")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isOk())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      verify(userRepository, times(1)).save(user);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 has been restored", json.get("message"));
+      assertEquals(false, user.getSuspended());
+  }
+
+  @WithMockUser(roles = { "ADMIN" })
+  @Test
+  public void testRestoreUser_notFound() throws Exception {
+      when(userRepository.findById(eq(1L))).thenReturn(Optional.empty());
+
+      MvcResult response = mockMvc.perform(post("/api/admin/users/restore")
+                      .param("userid", "1")
+                      .with(csrf()))
+              .andExpect(status().isNotFound())
+              .andReturn();
+
+      // assert
+      verify(userRepository, times(1)).findById(1L);
+      Map<String, Object> json = responseToJson(response);
+      assertEquals("User with id 1 not found", json.get("message"));
   }
 }


### PR DESCRIPTION
## Overview
In this PR, endpoints are added to the Users Controller to restore and suspend a user. These update the "suspend" field that was created in the Users entity in the previous issue. See swagger interface below for testing.

## Screenshots
<img width="1179" alt="Screenshot 2024-05-23 at 11 24 59 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/89555340/a6dfac80-dd11-47db-835a-47ce87d7a564">
<img width="1425" alt="Screenshot 2024-05-23 at 11 26 43 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/89555340/1a9ba61e-8e10-41bc-b02c-a6df673632d0">
<img width="1422" alt="Screenshot 2024-05-23 at 11 26 59 AM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/89555340/59e5121c-0155-4ecf-96b5-bb52d3c40a9e">

## Future Possibilities
- This is the part of the EPIC: Admin can suspend/restore users issue (#124)

## Validation (Optional)
<!--Steps that someone else could take to make sure everything is working-->
1. Download this branch.
2. Run the project.
3. Go to the swagger interface.
4. Test the "suspend" and "restore" endpoints under "User Information".

## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 

## Linked Issues
Closes #38 
