### PR TITLE
Dakota - Swagger NavBar link Visibility Environment Variable for dokku

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -5,7 +5,7 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
 spring.h2.console.enabled=true
-app.showSwaggerUILink=true
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:true}}
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,3 +3,5 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+
+app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}


### PR DESCRIPTION
## Overview
In this PR I added functionality to display Swagger Link with SHOW_SWAGGER_UI_LINK environment variable on dokku

This allows for a cleaner user experience when playing the game, and the swagger is not required to be accessed

## Screenshots
SHOW_SWAGGER_UI_LINK=false
<img width="355" alt="Screenshot 2024-05-23 at 2 39 07 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/24783417/58367a10-d65f-4032-8b2e-462b9738626d">
SHOW_SWAGGER_UI_LINK=true
<img width="376" alt="Screenshot 2024-05-23 at 2 40 23 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/24783417/01ec3d78-d248-42b3-a045-5f218ca06674">


## Future Possibilities
- Looking to do the same thing with the H2-Console link

## Validation
1. Visit my dokku to see the link is not there
2. Checkout your dokku to my branch
3. Add SHOW_SWAGGER_UI_LINK to your dokku
4. Toggle to view functionality

## Linked Issues
Closes #41 
