### PR TITLE
Dakota - H2 Console NavBar link Visibility Environment Variable

### DIFF
--- a/src/main/resources/application-development.properties
+++ b/src/main/resources/application-development.properties
@@ -4,7 +4,7 @@ spring.datasource.url=jdbc:h2:file:./target/db-development
 spring.datasource.username=sa
 spring.datasource.password=password
 spring.h2.console.settings.web-allow-others=true
-spring.h2.console.enabled=true
+spring.h2.console.enabled=${H2_CONSOLE_ENABLE:${env.H2_CONSOLE_ENABLE:true}}
 app.showSwaggerUILink=true
 app.sourceRepo=${SOURCE_REPO:${$env.SOURCE_REPO:https://github.com/ucsb-cs156/proj-happycows}}
 

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -5,3 +5,4 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 
 spring.h2.console.enabled=${H2_CONSOLE_ENABLE:${env.H2_CONSOLE_ENABLE:false}}
+spring.h2.console.settings.web-allow-others=true

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -5,8 +5,3 @@ spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 
 app.showSwaggerUILink=${SHOW_SWAGGER_UI_LINK:${env.SHOW_SWAGGER_UI_LINK:false}}
-
-spring.h2.console.enabled=${H2_CONSOLE_ENABLE:${env.H2_CONSOLE_ENABLE:false}}
-spring.h2.console.settings.web-allow-others=true
-spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
-spring.datasource.initialization-mode=always

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -3,3 +3,5 @@ spring.datasource.username=${JDBC_DATABASE_USERNAME}
 spring.datasource.password=${JDBC_DATABASE_PASSWORD}
 
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
+
+spring.h2.console.enabled=${H2_CONSOLE_ENABLE:${env.H2_CONSOLE_ENABLE:false}}

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -6,3 +6,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL9Dialect
 
 spring.h2.console.enabled=${H2_CONSOLE_ENABLE:${env.H2_CONSOLE_ENABLE:false}}
 spring.h2.console.settings.web-allow-others=true
+spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
+spring.datasource.initialization-mode=always


### PR DESCRIPTION
## Overview
In this PR I added functionality to display H2 Console Link with H2_CONSOLE_ENABLE environment variable on dokku

This allows for a cleaner user experience when playing the game, and the H2 Console is not required to be accessed

## Screenshots
H2_CONSOLE_ENABLE=false
<img width="355" alt="Screenshot 2024-05-23 at 2 39 07 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/24783417/58367a10-d65f-4032-8b2e-462b9738626d">
H2_CONSOLE_ENABLE=true
<img width="395" alt="Screenshot 2024-05-23 at 5 20 25 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/24783417/ae44bfeb-79ff-404d-8d75-f5bd2d473249">


## Validation
1. Visit my dokku to see the link is not there
2. Checkout your dokku to my branch
3. Add H2_CONSOLE_ENABLE to your dokku
4. Toggle to view functionality

## Linked Issues
Closes #44 
