### PR TITLE
Pc fix pitest broken suddenly on main

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,3 +123,25 @@ In order to run the end-to-end tests 'not headless' use the following instead of
 ```
 INTEGRATION=true HEADLESS=false mvn failsafe:integration-test
 ```
+
+## Partial pitest runs
+
+This repo has support for partial pitest runs
+
+For example, to run pitest on just one class, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController
+```
+
+To run pitest on just one package, use:
+
+```
+mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.\*
+```
+
+To run full mutation test coverage, as usual, use:
+
+```
+mvn pitest:mutationCoverage
+```

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <description>A Simulation Game of the Tragedy of the Commons.</description>
     <properties>
         <java.version>17</java.version>
+        <targetClasses>${targetClasses:edu.ucsb.cs156.*}</targetClasses>
     </properties>
     <dependencies>
         <dependency>
@@ -237,7 +238,7 @@
                     </historyOutputFile>
                     <verbose>true</verbose>
                     <targetClasses>
-                        <param>edu.ucsb.cs156.*</param>
+                        <param>${targetClasses}</param>
                     </targetClasses>
                     <targetTests>
                         <param>edu.ucsb.cs156.*</param>

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelper.java
@@ -19,7 +19,7 @@ import edu.ucsb.cs156.happiercows.entities.CommonStats;
 
 public class CommonStatsCSVHelper {
 
-  private CommonStatsCSVHelper() {}
+  public CommonStatsCSVHelper() {}
 
   /**
    * This method is a hack to avoid a pitest issue; it isn't possible to 

--- a/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelper.java
@@ -19,7 +19,7 @@ import edu.ucsb.cs156.happiercows.entities.ReportLine;
 
 public class ReportCSVHelper {
 
-  private ReportCSVHelper() {}
+  public ReportCSVHelper() {}
 
   /**
    * This method is a hack to avoid a jacoco issue; it isn't possible to 

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/ProfitsControllerTests.java
@@ -13,8 +13,6 @@ import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 import edu.ucsb.cs156.happiercows.repositories.UserRepository;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -25,7 +23,6 @@ import org.springframework.security.test.context.support.WithMockUser;
 import org.springframework.test.web.servlet.MvcResult;
 
 import java.time.LocalDateTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -64,10 +61,13 @@ public class ProfitsControllerTests extends ControllerTestCase {
             .commons(commons).build();
 
     LocalDateTime t1 = LocalDateTime.parse("2022-03-05T15:50:10");
+    LocalDateTime t2 = LocalDateTime.parse("2022-03-05T16:50:10");
+    LocalDateTime t3 = LocalDateTime.parse("2022-03-05T17:50:10");
 
-    Profit p1 = Profit.builder().id(41).amount(123.45).timestamp(t1).userCommons(uc1).numCows(1).avgCowHealth(80).build();
+
+    Profit p1 = Profit.builder().id(41).amount(123.45).timestamp(t3).userCommons(uc1).numCows(1).avgCowHealth(80).build();
     Profit p2 = Profit.builder().id(42).amount(23.45).timestamp(t1).userCommons(uc1).numCows(1).avgCowHealth(80).build();
-    Profit p3 = Profit.builder().id(43).amount(3.45).timestamp(t1).userCommons(uc1).numCows(1).avgCowHealth(80).build();
+    Profit p3 = Profit.builder().id(43).amount(3.45).timestamp(t2).userCommons(uc1).numCows(1).avgCowHealth(80).build();
 
     List<Profit> profits = List.of(p1);
     List<Profit> profits2 = List.of(p1, p2, p3);
@@ -212,6 +212,6 @@ public class ProfitsControllerTests extends ControllerTestCase {
 
         assertEquals(3, jsonResponse.get("totalElements").asInt());
         assertEquals(2, jsonResponse.get("totalPages").asInt());
-        assertEquals(p3.getAmount(), jsonResponse.get("content").get(0).get("amount").asDouble(), 0.01);
+        assertEquals(p2.getAmount(), jsonResponse.get("content").get(0).get("amount").asDouble(), 0.01);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelperTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelperTests.java
@@ -7,7 +7,7 @@ public class CommonStatsCSVHelperTests {
     
     @Test
     void call_constructor_so_pitest_does_not_complain() throws Exception {
-        CommonStatsCSVHelperTests helper = new CommonStatsCSVHelperTests();
+        CommonStatsCSVHelper helper = new CommonStatsCSVHelper();
         assertTrue(true);
     }
 }

--- a/src/test/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelperTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/helpers/CommonStatsCSVHelperTests.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.happiercows.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class CommonStatsCSVHelperTests {
+    
+    @Test
+    void call_constructor_so_pitest_does_not_complain() throws Exception {
+        CommonStatsCSVHelperTests helper = new CommonStatsCSVHelperTests();
+        assertTrue(true);
+    }
+}
+

--- a/src/test/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelperTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/helpers/ReportCSVHelperTests.java
@@ -1,0 +1,14 @@
+package edu.ucsb.cs156.happiercows.helpers;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import org.junit.jupiter.api.Test;
+
+public class ReportCSVHelperTests {
+    
+    @Test
+    void call_constructor_so_pitest_does_not_complain() throws Exception {
+        ReportCSVHelper helper = new ReportCSVHelper();
+        assertTrue(true);
+    }
+}
+


### PR DESCRIPTION
In this STAFF pr, we address sudden unexplained pitest coverage gaps on main.

We also add support for incremental pitest runs.

## Partial pitest runs

This repo has support for partial pitest runs

For example, to run pitest on just one class, use:

```
mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.CommonsController
```

To run pitest on just one package, use:

```
mvn pitest:mutationCoverage -DtargetClasses=edu.ucsb.cs156.happiercows.controllers.\*
```

To run full mutation test coverage, as usual, use:

```
mvn pitest:mutationCoverage
```