### PR TITLE
Fixed Post Announcement Endpoint

### DIFF
--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.common.Json;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import edu.ucsb.cs156.happiercows.entities.Announcement;
 import edu.ucsb.cs156.happiercows.repositories.AnnouncementRepository;
@@ -24,9 +27,15 @@ import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 
 import org.springframework.security.core.Authentication;
 import java.util.Date;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import java.time.LocalDateTime;
+import java.text.ParseException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Optional;
+import java.util.TimeZone;
 
 @Tag(name = "Announcements")
 @RequestMapping("/api/announcements")
@@ -49,8 +58,8 @@ public class AnnouncementsController extends ApiController{
     @PostMapping("/post")
     public ResponseEntity<Object> createAnnouncement(
         @Parameter(description = "The id of the common") @RequestParam Long commonsId,
-        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
-        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
+        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
 
         User user = getCurrentUser().getUser();
@@ -69,13 +78,13 @@ public class AnnouncementsController extends ApiController{
 
         if (startDate == null) { 
             log.info("Start date not specified. Defaulting to current date.");
-            startDate = new Date(); 
+            startDate = LocalDateTime.now();
         }
 
         if (announcementText == "") {
             return ResponseEntity.badRequest().body("Announcement cannot be empty.");
         }
-        if (endDate != null && startDate.after(endDate)) {
+        if(endDate != null && startDate.isAfter(endDate)){
             return ResponseEntity.badRequest().body("Start date must be before end date.");
         }
 
@@ -135,8 +144,8 @@ public class AnnouncementsController extends ApiController{
     public ResponseEntity<Object> editAnnouncement(
         @Parameter(description = "The id of the announcement") @RequestParam Long id,
         @Parameter(description = "The id of the common") @RequestParam Long commonsId,
-        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
-        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
+        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
 
         User user = getCurrentUser().getUser();
@@ -159,10 +168,10 @@ public class AnnouncementsController extends ApiController{
 
         if (startDate == null) {
             log.info("Start date not specified. Defaulting to current date.");
-            startDate = new Date();
+            startDate = LocalDateTime.now();
         }
 
-        if (endDate != null && startDate.after(endDate)) {
+        if(endDate != null && startDate.isAfter(endDate)){
             return ResponseEntity.badRequest().body("Start date must be before end date.");
         }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Announcement.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Announcement.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
@@ -24,10 +24,10 @@ public class Announcement {
     private long commonsId;
 
     @Column(name="start_date", nullable = false)
-    private Date startDate;
+    private LocalDateTime startDate;
 
     @Column(name="end_date", nullable = true)
-    private Date endDate;
+    private LocalDateTime endDate;
 
     @Column(name="announcement_text", nullable = false)
     private String announcementText;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -8,17 +8,15 @@ import static org.mockito.Mockito.when;
 
 import static org.mockito.ArgumentMatchers.any;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Optional;
-import java.util.Date;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import java.time.LocalDateTime;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.tomcat.jni.Local;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -73,10 +71,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2025-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2025-12-12T00:00:00");
 
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
@@ -94,7 +90,6 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         verify(announcementRepository, atLeastOnce()).save(any(Announcement.class));
         String announcementString = response.getResponse().getContentAsString();
         String expectedResponseString = mapper.writeValueAsString(announcementObj);
-        log.info("Got back from API: {}",announcementString);
         assertEquals(expectedResponseString, announcementString);
     }
 
@@ -107,10 +102,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
 
@@ -165,9 +157,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
 
@@ -193,10 +183,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Announcement";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2022-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2023-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
 
@@ -222,9 +210,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
 
@@ -268,9 +254,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
@@ -300,9 +284,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long userId = 1L;
         String announcement1 = "Hello world!";
         String announcement2 = "Hello world2!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj1 = Announcement.builder().id(id1).commonsId(commonsId).startDate(start).announcementText(announcement1).build();
         Announcement announcementObj2 = Announcement.builder().id(id2).commonsId(commonsId).startDate(start).announcementText(announcement2).build();
@@ -340,9 +322,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long userId = 1L;
         String announcement1 = "Hello world!";
         String announcement2 = "Hello world2!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj1 = Announcement.builder().id(id1).commonsId(commonsId).startDate(start).announcementText(announcement1).build();
         Announcement announcementObj2 = Announcement.builder().id(id2).commonsId(commonsId).startDate(start).announcementText(announcement2).build();
@@ -375,9 +355,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         String announcement1 = "Hello world!";
         String announcement2 = "Hello world2!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj1 = Announcement.builder().id(id1).commonsId(commonsId).startDate(start).announcementText(announcement1).build();
         Announcement announcementObj2 = Announcement.builder().id(id2).commonsId(commonsId).startDate(start).announcementText(announcement2).build();
@@ -409,9 +387,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long commonsId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -451,9 +427,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long commonsId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -471,8 +445,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
 
         // arrange
         String editedAnnouncement = "Hello world edited!";
-        Date editedStart = sdf.parse("2023-03-03T17:39:43.000-08:00");
-        Date editedEnd = sdf.parse("2025-03-03T17:39:43.000-08:00");
+        LocalDateTime editedStart = LocalDateTime.parse("2023-12-12T00:00:00");
+        LocalDateTime editedEnd = LocalDateTime.parse("2025-12-12T00:00");
 
         Announcement editedAnnouncementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(editedStart).endDate(editedEnd).announcementText(editedAnnouncement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -526,9 +500,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -553,9 +525,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.empty());
 
@@ -580,9 +550,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -608,10 +576,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "Announcement";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2022-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2023-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));


### PR DESCRIPTION
## Overview
In this PR, I fixed the backend for post announcement. Before, when trying to create an announcement on Swagger, giving a date such as 2024-12-12T00:00:00 would give Error 400. I changed the announcement to take LocalDateTime instead of Date with the right formatting so that there are no errors. The Post endpoint for announcement is now working properly with valid inputs.
Deployment: https://happycows-brycewangg-dev.dokku-06.cs.ucsb.edu

## Screenshots
<img width="1423" alt="Screenshot 2024-05-25 at 10 20 55 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/91992001/55a61f09-3edb-45b5-a735-fb7f68fa8ec4">

## Tests
<!--Add any additional tests or required tests-->
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100%  

## Linked Issues
<!--Issues related to the PR-->
#8 