### PR TITLE
Announcements Create Button

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -20,6 +20,7 @@ import PlayPage from "main/pages/PlayPage";
 import NotFoundPage from "main/pages/NotFoundPage";
 import AdminViewPlayPage from "main/pages/AdminViewPlayPage";
 import AdminListAnnouncementsPage from "main/pages/AdminListAnnouncementsPage";
+import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
 
 function App() {
     const { data: currentUser } = useCurrentUser();
@@ -52,6 +53,10 @@ function App() {
             <Route
                 path="/admin/announcements/:commonsId"
                 element={<AdminListAnnouncementsPage />}
+            />
+            <Route
+                path="/admin/announcements/:commonsId/create"
+                element={<AdminCreateAnnouncementsPage />}
             />
         </>
     ) : null;

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,54 +1,14 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
-import { useParams } from "react-router-dom";
 import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
-import { Navigate } from 'react-router-dom'
-import { toast } from "react-toastify"
-
-import { useBackendMutation } from "main/utils/useBackend";
 
 const AdminCreateAnnouncementsPage = () => {
-
-    let { commonsId } = useParams();
-
-    const objectToAxiosParams = (announcement) => ({        
-        url: "/api/announcements/post",
-        method: "POST",
-        params: {
-            commonsId: announcement.commonsId,
-            startDate: announcement.startDate,
-            endDate: announcement.endDate,
-            announcementText: announcement.announcementText
-        }
-    });
-
-    const onSuccess = (announcement) => {
-        toast(`Announcement successfully created - id: ${announcement.id}`);
-    }
-   
-    const mutation = useBackendMutation(
-        objectToAxiosParams,
-        { onSuccess },
-        // Stryker disable next-line all : hard to set up test for caching
-        ["/api/announcements/all"]
-    );
-
-    const { isSuccess } = mutation
-
-    const onSubmit = async (data) => {
-        console.log("Submitting data:", { ...data, commonsId });
-        mutation.mutate({ ...data, commonsId });
-    }
-
-    if (isSuccess) {
-        return <Navigate to={`/admin/announcements/${commonsId}`} />
-    }
 
     return (
         <BasicLayout>
             <h2>Create Announcement</h2>
-            <AnnouncementForm submitAction={onSubmit}/>
+            <AnnouncementForm />
         </BasicLayout>
     );
 };

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,14 +1,53 @@
 import React from "react";
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
 
+import { useParams } from "react-router-dom";
 import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
+import { Navigate } from 'react-router-dom'
+import { toast } from "react-toastify"
+
+import { useBackendMutation } from "main/utils/useBackend";
 
 const AdminCreateAnnouncementsPage = () => {
+
+    let { commonsId } = useParams();
+
+    const objectToAxiosParams = (announcement) => ({        
+        url: "/api/announcements/post",
+        method: "POST",
+        params: {
+            commonsId: announcement.commonsId,
+            startDate: announcement.startDate,
+            endDate: announcement.endDate,
+            announcementText: announcement.announcementText
+        }
+    });
+
+    const onSuccess = (announcement) => {
+        toast(`Announcement successfully created - id: ${announcement.id}`);
+    }
+   
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/announcements/all"]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        mutation.mutate({ ...data, commonsId });
+    }
+
+    if (isSuccess) {
+        return <Navigate to={`/admin/announcements/${commonsId}`} />
+    }
 
     return (
         <BasicLayout>
             <h2>Create Announcement</h2>
-            <AnnouncementForm />
+            <AnnouncementForm submitAction={onSubmit}/>
         </BasicLayout>
     );
 };

--- a/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminCreateAnnouncementsPage.js
@@ -1,0 +1,56 @@
+import React from "react";
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+import { useParams } from "react-router-dom";
+import AnnouncementForm from "main/components/Announcement/AnnouncementForm";
+import { Navigate } from 'react-router-dom'
+import { toast } from "react-toastify"
+
+import { useBackendMutation } from "main/utils/useBackend";
+
+const AdminCreateAnnouncementsPage = () => {
+
+    let { commonsId } = useParams();
+
+    const objectToAxiosParams = (announcement) => ({        
+        url: "/api/announcements/post",
+        method: "POST",
+        params: {
+            commonsId: announcement.commonsId,
+            startDate: announcement.startDate,
+            endDate: announcement.endDate,
+            announcementText: announcement.announcementText
+        }
+    });
+
+    const onSuccess = (announcement) => {
+        toast(`Announcement successfully created - id: ${announcement.id}`);
+    }
+   
+    const mutation = useBackendMutation(
+        objectToAxiosParams,
+        { onSuccess },
+        // Stryker disable next-line all : hard to set up test for caching
+        ["/api/announcements/all"]
+    );
+
+    const { isSuccess } = mutation
+
+    const onSubmit = async (data) => {
+        console.log("Submitting data:", { ...data, commonsId });
+        mutation.mutate({ ...data, commonsId });
+    }
+
+    if (isSuccess) {
+        return <Navigate to={`/admin/announcements/${commonsId}`} />
+    }
+
+    return (
+        <BasicLayout>
+            <h2>Create Announcement</h2>
+            <AnnouncementForm submitAction={onSubmit}/>
+        </BasicLayout>
+    );
+};
+
+export default AdminCreateAnnouncementsPage;

--- a/frontend/src/main/pages/AdminListAnnouncementsPage.js
+++ b/frontend/src/main/pages/AdminListAnnouncementsPage.js
@@ -17,7 +17,7 @@ export default function AnnouncementsPage() {
             return (
                 <Button
                     variant="primary"
-                    href="/announcements/create"
+                    href={`/admin/announcements/${commonsId}/create`}
                     style={{ float: "right" }}
                 >
                     Create Announcement 

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -1,0 +1,58 @@
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {QueryClient, QueryClientProvider} from "react-query";
+import {MemoryRouter} from "react-router-dom";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+import {apiCurrentUserFixtures} from "fixtures/currentUserFixtures";
+import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
+import healthUpdateStrategyListFixtures from "../../fixtures/healthUpdateStrategyListFixtures";
+import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
+
+const mockedNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockedNavigate(x); return null; }
+    };
+});
+
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
+
+describe("AdminCreateAnnouncementsPage tests", () => {
+    const axiosMock = new AxiosMockAdapter(axios);
+    const queryClient = new QueryClient();
+
+    beforeEach(() => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+
+        axiosMock.onGet("/api/commons/all-health-update-strategies")
+            .reply(200, healthUpdateStrategyListFixtures.simple);
+    });
+
+    test("renders without crashing", async () => {
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminCreateAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        expect(await screen.findByText("Create Announcement")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -1,4 +1,4 @@
-import {render, screen} from "@testing-library/react";
+import {fireEvent, render, screen, waitFor} from "@testing-library/react";
 import {QueryClient, QueryClientProvider} from "react-query";
 import {MemoryRouter} from "react-router-dom";
 import axios from "axios";
@@ -9,13 +9,14 @@ import {systemInfoFixtures} from "fixtures/systemInfoFixtures";
 import healthUpdateStrategyListFixtures from "../../fixtures/healthUpdateStrategyListFixtures";
 import AdminCreateAnnouncementsPage from "main/pages/AdminCreateAnnouncementsPage";
 
-const mockedNavigate = jest.fn();
+const mockNavigate = jest.fn();
 jest.mock('react-router-dom', () => {
     const originalModule = jest.requireActual('react-router-dom');
     return {
         __esModule: true,
         ...originalModule,
-        Navigate: (x) => { mockedNavigate(x); return null; }
+        Navigate: (x) => { mockNavigate(x); return null; },
+        useParams: () => ({ commonsId: '1' })
     };
 });
 
@@ -53,6 +54,58 @@ describe("AdminCreateAnnouncementsPage tests", () => {
         );
 
         expect(await screen.findByText("Create Announcement")).toBeInTheDocument();
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const announcement = {
+            id: 17,
+            commonsId: 1,
+            startDate: "2022-02-02T00:00",
+            endDate: "2022-03-02T00:00",
+            announcementText: "Great"
+        };
+
+        axiosMock.onPost("/api/announcements/post").reply(200, announcement);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <AdminCreateAnnouncementsPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        await waitFor(() => {
+            expect(screen.getByTestId("AnnouncementForm-startDate")).toBeInTheDocument();
+        });
+
+        const startDateField = screen.getByTestId("AnnouncementForm-startDate");
+        const endDateField = screen.getByTestId("AnnouncementForm-endDate");
+        const announcementTextField = screen.getByTestId("AnnouncementForm-announcementText");
+        const submitButton = screen.getByTestId("AnnouncementForm-submit");
+
+        fireEvent.change(startDateField, { target: { value: '2022-02-02T00:00' } });
+        fireEvent.change(endDateField, { target: { value: '2022-03-02T00:00' } });
+        fireEvent.change(announcementTextField, { target: { value: 'Great' } });
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "commonsId": "1",
+                "startDate": "2022-02-02T00:00",
+                "endDate": "2022-03-02T00:00",
+                "announcementText": "Great"
+        });
+
+        expect(mockToast).toBeCalledWith("Announcement successfully created - id: 17");
+        expect(mockNavigate).toBeCalledWith({ "to": "/admin/announcements/1" });
     });
 
 });

--- a/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminCreateAnnouncementsPage.test.js
@@ -1,4 +1,4 @@
-import {fireEvent, render, screen, waitFor} from "@testing-library/react";
+import {render, screen} from "@testing-library/react";
 import {QueryClient, QueryClientProvider} from "react-query";
 import {MemoryRouter} from "react-router-dom";
 import axios from "axios";

--- a/frontend/src/tests/pages/AdminListAnnouncementsPage.test.js
+++ b/frontend/src/tests/pages/AdminListAnnouncementsPage.test.js
@@ -62,7 +62,7 @@ describe("AdminListAnnouncementsPage tests", () => {
             expect(screen.getByText(/Create Announcement/)).toBeInTheDocument();
         });
         const button = screen.getByText(/Create Announcement/);
-        expect(button).toHaveAttribute("href", "/announcements/create");
+        expect(button).toHaveAttribute("href", "/admin/announcements/1/create");
         expect(button).toHaveAttribute("style", "float: right;");
     });
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -1,6 +1,8 @@
 package edu.ucsb.cs156.happiercows.controllers;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.common.Json;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.extern.slf4j.Slf4j;
 import io.swagger.v3.oas.annotations.Operation;
@@ -14,6 +16,7 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.format.annotation.DateTimeFormat;
 
 import edu.ucsb.cs156.happiercows.entities.Announcement;
 import edu.ucsb.cs156.happiercows.repositories.AnnouncementRepository;
@@ -24,9 +27,15 @@ import edu.ucsb.cs156.happiercows.repositories.UserCommonsRepository;
 
 import org.springframework.security.core.Authentication;
 import java.util.Date;
+import java.text.SimpleDateFormat;
+import java.util.TimeZone;
+import java.time.LocalDateTime;
+import java.text.ParseException;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 
 import java.util.Optional;
+import java.util.TimeZone;
 
 @Tag(name = "Announcements")
 @RequestMapping("/api/announcements")
@@ -49,8 +58,8 @@ public class AnnouncementsController extends ApiController{
     @PostMapping("/post")
     public ResponseEntity<Object> createAnnouncement(
         @Parameter(description = "The id of the common") @RequestParam Long commonsId,
-        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
-        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
+        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
 
         User user = getCurrentUser().getUser();
@@ -69,13 +78,13 @@ public class AnnouncementsController extends ApiController{
 
         if (startDate == null) { 
             log.info("Start date not specified. Defaulting to current date.");
-            startDate = new Date(); 
+            startDate = LocalDateTime.now();
         }
 
         if (announcementText == "") {
             return ResponseEntity.badRequest().body("Announcement cannot be empty.");
         }
-        if (endDate != null && startDate.after(endDate)) {
+        if(endDate != null && startDate.isAfter(endDate)){
             return ResponseEntity.badRequest().body("Start date must be before end date.");
         }
 
@@ -135,8 +144,8 @@ public class AnnouncementsController extends ApiController{
     public ResponseEntity<Object> editAnnouncement(
         @Parameter(description = "The id of the announcement") @RequestParam Long id,
         @Parameter(description = "The id of the common") @RequestParam Long commonsId,
-        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) Date startDate,
-        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
+        @Parameter(description = "The datetime at which the announcement will be shown (defaults to current time)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime startDate,
+        @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
 
         User user = getCurrentUser().getUser();
@@ -159,10 +168,10 @@ public class AnnouncementsController extends ApiController{
 
         if (startDate == null) {
             log.info("Start date not specified. Defaulting to current date.");
-            startDate = new Date();
+            startDate = LocalDateTime.now();
         }
 
-        if (endDate != null && startDate.after(endDate)) {
+        if(endDate != null && startDate.isAfter(endDate)){
             return ResponseEntity.badRequest().body("Start date must be before end date.");
         }
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -53,6 +53,11 @@ public class AnnouncementsController extends ApiController{
         @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
 
+        log.info("Received commonsId: " + commonsId);
+        log.info("Received startDate: " + startDate);
+        log.info("Received endDate: " + endDate);
+        log.info("Received announcementText: " + announcementText);
+
         User user = getCurrentUser().getUser();
         Long userId = user.getId();
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsController.java
@@ -53,11 +53,6 @@ public class AnnouncementsController extends ApiController{
         @Parameter(description = "The datetime at which the announcement will stop being shown (optional)") @RequestParam(required = false) Date endDate,
         @Parameter(description = "The announcement to be sent out") @RequestParam String announcementText) {
 
-        log.info("Received commonsId: " + commonsId);
-        log.info("Received startDate: " + startDate);
-        log.info("Received endDate: " + endDate);
-        log.info("Received announcementText: " + announcementText);
-
         User user = getCurrentUser().getUser();
         Long userId = user.getId();
 

--- a/src/main/java/edu/ucsb/cs156/happiercows/entities/Announcement.java
+++ b/src/main/java/edu/ucsb/cs156/happiercows/entities/Announcement.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 import javax.persistence.*;
 
 import org.hibernate.annotations.CreationTimestamp;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Data
 @AllArgsConstructor
@@ -24,10 +24,10 @@ public class Announcement {
     private long commonsId;
 
     @Column(name="start_date", nullable = false)
-    private Date startDate;
+    private LocalDateTime startDate;
 
     @Column(name="end_date", nullable = true)
-    private Date endDate;
+    private LocalDateTime endDate;
 
     @Column(name="announcement_text", nullable = false)
     private String announcementText;

--- a/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
+++ b/src/test/java/edu/ucsb/cs156/happiercows/controllers/AnnouncementsControllerTests.java
@@ -8,17 +8,15 @@ import static org.mockito.Mockito.when;
 
 import static org.mockito.ArgumentMatchers.any;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Optional;
-import java.util.Date;
-import java.text.SimpleDateFormat;
-import java.util.TimeZone;
+import java.time.LocalDateTime;
 
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import org.apache.tomcat.jni.Local;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.AutoConfigureDataJpa;
@@ -73,10 +71,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2025-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2025-12-12T00:00:00");
 
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
@@ -94,7 +90,6 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         verify(announcementRepository, atLeastOnce()).save(any(Announcement.class));
         String announcementString = response.getResponse().getContentAsString();
         String expectedResponseString = mapper.writeValueAsString(announcementObj);
-        log.info("Got back from API: {}",announcementString);
         assertEquals(expectedResponseString, announcementString);
     }
 
@@ -107,10 +102,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
 
@@ -165,9 +157,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
 
@@ -193,10 +183,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Announcement";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2022-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2023-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
 
@@ -222,9 +210,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
 
@@ -268,9 +254,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
@@ -300,9 +284,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long userId = 1L;
         String announcement1 = "Hello world!";
         String announcement2 = "Hello world2!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj1 = Announcement.builder().id(id1).commonsId(commonsId).startDate(start).announcementText(announcement1).build();
         Announcement announcementObj2 = Announcement.builder().id(id2).commonsId(commonsId).startDate(start).announcementText(announcement2).build();
@@ -340,9 +322,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long userId = 1L;
         String announcement1 = "Hello world!";
         String announcement2 = "Hello world2!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj1 = Announcement.builder().id(id1).commonsId(commonsId).startDate(start).announcementText(announcement1).build();
         Announcement announcementObj2 = Announcement.builder().id(id2).commonsId(commonsId).startDate(start).announcementText(announcement2).build();
@@ -375,9 +355,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         String announcement1 = "Hello world!";
         String announcement2 = "Hello world2!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj1 = Announcement.builder().id(id1).commonsId(commonsId).startDate(start).announcementText(announcement1).build();
         Announcement announcementObj2 = Announcement.builder().id(id2).commonsId(commonsId).startDate(start).announcementText(announcement2).build();
@@ -409,9 +387,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long commonsId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -451,9 +427,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long id = 0L;
         Long commonsId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -471,8 +445,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
 
         // arrange
         String editedAnnouncement = "Hello world edited!";
-        Date editedStart = sdf.parse("2023-03-03T17:39:43.000-08:00");
-        Date editedEnd = sdf.parse("2025-03-03T17:39:43.000-08:00");
+        LocalDateTime editedStart = LocalDateTime.parse("2023-12-12T00:00:00");
+        LocalDateTime editedEnd = LocalDateTime.parse("2025-12-12T00:00");
 
         Announcement editedAnnouncementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(editedStart).endDate(editedEnd).announcementText(editedAnnouncement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -526,9 +500,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -553,9 +525,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "Hello world!";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.empty());
 
@@ -580,9 +550,7 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));
@@ -608,10 +576,8 @@ public class AnnouncementsControllerTests extends ControllerTestCase {
         Long commonsId = 1L;
         Long userId = 1L;
         String announcement = "Announcement";
-        SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
-        sdf.setTimeZone(TimeZone.getTimeZone("GMT-8:00"));
-        Date start = sdf.parse("2024-03-03T17:39:43.000-08:00");
-        Date end = sdf.parse("2022-03-03T17:39:43.000-08:00");
+        LocalDateTime start = LocalDateTime.parse("2024-12-12T00:00:00");
+        LocalDateTime end = LocalDateTime.parse("2023-12-12T00:00:00");
 
         Announcement announcementObj = Announcement.builder().id(id).commonsId(commonsId).startDate(start).endDate(end).announcementText(announcement).build();
         when(announcementRepository.findByAnnouncementId(id)).thenReturn(Optional.of(announcementObj));


### PR DESCRIPTION
## Overview
In this PR, I added a Create Announcement page that is directed to /admin/announcements/{commonsId}/create. This page will allow the admin to make an announcement to the commons that is implicitly defined. The Create button is working and will redirect the user back to the list of announcements when an announcement is successfully created.
Deployment: https://happycows-brycewangg-dev.dokku-06.cs.ucsb.edu/

## Screenshots (Optional)
<img width="1327" alt="Screenshot 2024-05-23 at 9 41 01 PM" src="https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/91992001/66d405d3-f80b-459b-a4cc-4798cd8df3ab">

## Tests
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
#8 
