### PR TITLE
PR: FIX [BUG: Remove toast spam on the "Whoa partner" page (Play page navigated to by user not member of commons)]

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -8,7 +8,7 @@ import CommonsPlay from "main/components/Commons/CommonsPlay";
 import FarmStats from "main/components/Commons/FarmStats";
 import ManageCows from "main/components/Commons/ManageCows";
 import Profits from "main/components/Commons/Profits";
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useBackendNoToast, useBackendMutation } from "main/utils/useBackend";
 import { hasRole } from "main/utils/currentUser";
 import { useCurrentUser } from "main/utils/currentUser";
 import Background from "../../assets/PlayPageBackground.jpg";
@@ -31,7 +31,7 @@ export default function PlayPage() {
     };
 
     // Stryker disable all
-    const { data: userCommons } = useBackend(
+    const { data: userCommons } = useBackendNoToast(
         [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
         {
             method: "GET",
@@ -44,7 +44,7 @@ export default function PlayPage() {
     // Stryker restore all
 
     // Stryker disable all
-    const { data: commonsPlus } = useBackend(
+    const { data: commonsPlus } = useBackendNoToast(
         [`/api/commons/plus?id=${commonsId}`],
         {
             method: "GET",
@@ -57,7 +57,7 @@ export default function PlayPage() {
     // Stryker restore all
 
     // Stryker disable all
-    const { data: userCommonsProfits } = useBackend(
+    const { data: userCommonsProfits } = useBackendNoToast(
         [`/api/profits/all/commonsid?commonsId=${commonsId}`],
         {
             method: "GET",

--- a/frontend/src/main/utils/useBackend.js
+++ b/frontend/src/main/utils/useBackend.js
@@ -49,6 +49,30 @@ export function useBackend(queryKey, axiosParameters, initialData, rest) {
         });
 }
 
+export function useBackendNoToast(queryKey, axiosParameters, initialData, rest) {
+//sends error messages to console.log rather than toast pop up
+    return useQuery({
+        queryKey: queryKey,
+        queryFn: async () => {
+            try {
+                const response = await axios(axiosParameters);
+                return response.data;
+            } catch (e) {
+                // Stryker disable next-line OptionalChaining
+                if (e.response?.data?.message) {
+                    console.log(e.response.data.message);
+                } else {
+                    const errorMessage = `Error communicating with backend via ${axiosParameters.method} on ${axiosParameters.url}`;
+                    toast.error(errorMessage);
+                }
+                throw e;
+            }
+        }, 
+        initialData: initialData,
+        ...rest
+        });
+}
+
 const wrappedParams = async (params) => {
     return await (await axios(params)).data;
 };

--- a/frontend/src/tests/utils/useBackend.test.js
+++ b/frontend/src/tests/utils/useBackend.test.js
@@ -4,11 +4,13 @@ import AxiosMockAdapter from "axios-mock-adapter";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { toast } from "react-toastify";
 
-import { useBackend, useBackendMutation } from "main/utils/useBackend";
+import { useBackend, useBackendNoToast, useBackendMutation } from "main/utils/useBackend";
 
 jest.mock('react-router-dom');
 
 const mockToast = jest.spyOn(toast, 'error').mockImplementation();
+const mockConsole = jest.spyOn(console, 'error').mockImplementation();
+const mockConsoleLog = jest.spyOn(console, 'log').mockImplementation();
 
 describe("utils/useBackend tests", () => {
     describe("utils/useBackend useBackend tests", () => {
@@ -85,6 +87,86 @@ describe("utils/useBackend tests", () => {
             expect(result.current.data).toEqual(["initialData"]);
             await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
             expect(mockToast).toHaveBeenCalledWith("Error communicating with backend via GET on /api/admin/users");
+
+            console.error.mockRestore();
+        });
+
+	test("useBackendNoToast handles 404 error correctly", async () => {
+            jest.spyOn(console, 'error');
+
+            // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
+            const queryClient = new QueryClient({
+                defaultOptions: {
+                    queries: {
+                        // ✅ turns retries off
+                        retry: false,
+                    },
+                },
+            });
+
+            const wrapper = ({ children }) => (
+                <QueryClientProvider client={queryClient}>
+                    {children}
+                </QueryClientProvider>
+            );
+
+            var axiosMock = new AxiosMockAdapter(axios);
+
+            axiosMock.onGet("/api/admin/users").reply(404, { message: "Error: Request failed with status code 404 TEST" });
+
+            const { result, waitFor } = renderHook(() => useBackendNoToast(
+                ["/api/admin/users"],
+                { method: "GET", url: "/api/admin/users" },
+                ["initialData"]
+            ), { wrapper });
+
+            await waitFor(() => result.current.isError);
+
+            expect(result.current.data).toEqual(["initialData"]);
+            await waitFor(() => expect(mockConsole).toHaveBeenCalledTimes(1));
+            expect(mockConsole).toHaveBeenCalledWith(Error("Request failed with status code 404"));
+            await waitFor(() => expect(mockConsoleLog).toHaveBeenCalledTimes(1));
+            expect(mockConsoleLog).toHaveBeenCalledWith("Error: Request failed with status code 404 TEST");
+
+            console.error.mockRestore()
+        });
+       
+        test("useBackendNoToast handles 404 error with no message", async () => {
+            jest.spyOn(console, 'error')
+
+            // See: https://react-query.tanstack.com/guides/testing#turn-off-retries
+            const queryClient = new QueryClient({
+                defaultOptions: {
+                    queries: {
+                        // ✅ turns retries off
+                        retry: false,
+                    },
+                },
+            })
+            const wrapper = ({ children }) => (
+                <QueryClientProvider client={queryClient}>
+                    {children}
+                </QueryClientProvider>
+            );
+
+            var axiosMock = new AxiosMockAdapter(axios);
+
+            axiosMock.onGet("/api/admin/users").reply(404);
+
+            const { result, waitFor } = renderHook(() => useBackendNoToast(
+                ["/api/admin/users"],
+                { method: "GET", url: "/api/admin/users" },
+                ["initialData"]
+            ), { wrapper });
+
+            await waitFor(() => result.current.isError);
+
+            expect(result.current.data).toEqual(["initialData"]);
+            await waitFor(() => expect(mockConsole).toHaveBeenCalledTimes(1));
+            expect(mockConsole).toHaveBeenCalledWith(Error("Request failed with status code 404"));
+            await waitFor(() => expect(mockToast).toHaveBeenCalledTimes(1));
+            expect(mockToast).toHaveBeenCalledWith("Error communicating with backend via GET on /api/admin/users");
+            await waitFor(() => expect(mockConsoleLog).toHaveBeenCalledTimes(0));
 
             console.error.mockRestore();
         });


### PR DESCRIPTION
## Overview
Implemented a new useBackendNoToast function that prints errors to console rather than to a toast pop up. This ensures the user is not spammed with error messages when entering an un-joined commons.

## Validation
Login and try to enter a not joined commons (eg: /play/# where # is the number of a commons you have not joined). You should see the "Whoa there" message without the pop up spam.
https://project-ok-at-computers-dev.dokku-06.cs.ucsb.edu/

## Possible Changes
Currently, errors are printed to the console. If possible, the errors can be returned by the useBackendNoToast function so that the content of error message can be directly used by code for error detection/handling purposes. 



## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #48 
