### PR TITLE
PR: FIX: BUG [nonexistent commons returns blank page / commons chat should not be available to users who are not part of a commons]

### DIFF
--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -181,7 +181,7 @@ export default function PlayPage() {
             <BasicLayout>
                 <Container>
                     {startDelay()}
-                    {!commonsExists && showAfterDelay &&  <h1>What are you doing here, friendo? This commons don't exist! You best be headin' back.</h1>}
+                    {!commonsExists && showAfterDelay &&  <h1>What are you doing here, friendo? This here commons don't exist! You best be headin' back.</h1>}
                     {userJoinedCommons && !!currentUser && <CommonsPlay currentUser={currentUser} />}
                     {userNotJoinedCommons && commonsExists && <h1>Whoa there, parder! You ain't a part of this commons!</h1> }            
                     {!!commonsPlus && (

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -218,7 +218,7 @@ export default function PlayPage() {
                     )}
                 </Container>
             </BasicLayout>
-            { (hasRole(currentUser, "ROLE_ADMIN") || (!!commonsPlus && commonsPlus.commons.showChat && userJoinedCommons)) &&
+            { ((hasRole(currentUser, "ROLE_ADMIN") && commonsExists) || (!!commonsPlus && commonsPlus.commons.showChat && userJoinedCommons)) &&
                 <div style={chatContainerStyle} data-testid="playpage-chat-div">
                     {!!isChatOpen && <ChatPanel commonsId={commonsId} />}
                     <Button

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -21,6 +21,13 @@ export default function PlayPage() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [message, setMessage] = useState();
     const [numCows, setNumCows] = useState(1);
+    const [showAfterDelay, setShowAfterDelay] = useState(false);
+    
+    const startDelay = () => {
+        setTimeout(() => {
+            setShowAfterDelay(true);
+        }, 100);
+    };
 
     const openModal = () => {
         setIsModalOpen(true);
@@ -159,7 +166,7 @@ export default function PlayPage() {
     };
     
     const commonsLoaded = !(typeof commonsPlus == 'undefined');
-    const commonsExists = (commons.some(com => parseInt(com.id) === parseInt(commonsId)));
+    const commonsExists = commons.some(com => parseInt(com.id) === parseInt(commonsId));
     const userJoinedCommons = commonsLoaded && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
     const userNotJoinedCommons = commonsLoaded && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
 
@@ -173,7 +180,8 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
-                    {!commonsExists &&  <h1>What are you doing here, friendo? This commons don't exist! You best be headin' back.</h1>}
+                    {startDelay()}
+                    {!commonsExists && showAfterDelay &&  <h1>What are you doing here, friendo? This commons don't exist! You best be headin' back.</h1>}
                     {userJoinedCommons && !!currentUser && <CommonsPlay currentUser={currentUser} />}
                     {userNotJoinedCommons && commonsExists && <h1>Whoa there, parder! You ain't a part of this commons!</h1> }            
                     {!!commonsPlus && (
@@ -210,7 +218,7 @@ export default function PlayPage() {
                     )}
                 </Container>
             </BasicLayout>
-            { (hasRole(currentUser, "ROLE_ADMIN") || (!!commonsPlus && commonsPlus.commons.showChat)) &&
+            { (hasRole(currentUser, "ROLE_ADMIN") || (!!commonsPlus && commonsPlus.commons.showChat && userJoinedCommons)) &&
                 <div style={chatContainerStyle} data-testid="playpage-chat-div">
                     {!!isChatOpen && <ChatPanel commonsId={commonsId} />}
                     <Button

--- a/frontend/src/main/pages/PlayPage.js
+++ b/frontend/src/main/pages/PlayPage.js
@@ -30,6 +30,14 @@ export default function PlayPage() {
         setIsModalOpen(false);
     };
 
+    // Stryker disable all : it is acceptable to exclude useBackend calls from mutation testing
+    const { data: commons } = useBackendNoToast(
+      ["/api/commons/all"],
+      { url: "/api/commons/all" },
+      []
+    );
+    // Stryker restore all
+
     // Stryker disable all
     const { data: userCommons } = useBackendNoToast(
         [`/api/usercommons/forcurrentuser?commonsId=${commonsId}`],
@@ -150,7 +158,8 @@ export default function PlayPage() {
         fontSize: "30px",
     };
     
-    const commonsLoaded = !(typeof commonsPlus == 'undefined')
+    const commonsLoaded = !(typeof commonsPlus == 'undefined');
+    const commonsExists = (commons.some(com => parseInt(com.id) === parseInt(commonsId)));
     const userJoinedCommons = commonsLoaded && (currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
     const userNotJoinedCommons = commonsLoaded && !(currentUser.root.user.commons.some(com => com.id === commonsPlus.commons.id));
 
@@ -164,8 +173,9 @@ export default function PlayPage() {
         >
             <BasicLayout>
                 <Container>
+                    {!commonsExists &&  <h1>What are you doing here, friendo? This commons don't exist! You best be headin' back.</h1>}
                     {userJoinedCommons && !!currentUser && <CommonsPlay currentUser={currentUser} />}
-                    {userNotJoinedCommons &&  <h1>Whoa there, parder! You ain't a part of this commons!</h1> }             
+                    {userNotJoinedCommons && commonsExists && <h1>Whoa there, parder! You ain't a part of this commons!</h1> }            
                     {!!commonsPlus && (
                         <CommonsOverview
                             commonsPlus={commonsPlus}

--- a/frontend/src/tests/components/Commons/CommonsOverview.test.js
+++ b/frontend/src/tests/components/Commons/CommonsOverview.test.js
@@ -51,7 +51,7 @@ describe("CommonsOverview tests", () => {
             </QueryClientProvider>
         );
         await waitFor(() => {
-            expect(axiosMock.history.get.length).toEqual(5);
+            expect(axiosMock.history.get.length).toEqual(6);
         });
         expect(await screen.findByTestId("user-leaderboard-button")).toBeInTheDocument();
         const leaderboardButton = screen.getByTestId("user-leaderboard-button");

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -545,7 +545,7 @@ describe("PlayPage tests", () => {
         
     })
 
-    test("user has entered nonexistant the commons (one commons created)", async () => {
+    test("user has entered nonexistent the commons (one commons created)", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -574,7 +574,7 @@ describe("PlayPage tests", () => {
   
     })
     
-    test("user has entered nonexistant the commons (two commons created)", async () => {
+    test("user has entered nonexistent the commons (two commons created)", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();
@@ -607,7 +607,7 @@ describe("PlayPage tests", () => {
         
     })
     
-    test("user has entered nonexistant the commons (no commons created)", async () => {
+    test("user has entered nonexistent the commons (no commons created)", async () => {
         
         axiosMock.reset();
         axiosMock.resetHistory();

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -379,9 +379,12 @@ describe("PlayPage tests", () => {
         await waitFor(() => {
             expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();    
         });
+        
+        await new Promise((r) => setTimeout(r, 100));
 
         expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
         expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
 
     })
     
@@ -425,8 +428,11 @@ describe("PlayPage tests", () => {
             expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();    
         });
 
+	await new Promise((r) => setTimeout(r, 100));
+
         expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
         expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
 	
     })
     
@@ -461,6 +467,10 @@ describe("PlayPage tests", () => {
                 </MemoryRouter>
             </QueryClientProvider>
         );
+        
+        await waitFor(() => {
+            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        });   
 
         await waitFor(() => {
             expect(screen.getByTestId("commons-card")).toBeInTheDocument();
@@ -471,8 +481,11 @@ describe("PlayPage tests", () => {
             expect(screen.getByText("Announcements")).toBeInTheDocument();
         });        
         
+        await new Promise((r) => setTimeout(r, 100));
+        
         expect(screen.getByTestId("commons-card")).toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         
     })
 
@@ -513,6 +526,10 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
+            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        });   
+
+        await waitFor(() => {
             expect(screen.getByTestId("commons-card")).toBeInTheDocument();
         });
         
@@ -520,8 +537,11 @@ describe("PlayPage tests", () => {
             expect(screen.getByText("Announcements")).toBeInTheDocument();
         });        
         
+        await new Promise((r) => setTimeout(r, 100));
+        
         expect(screen.getByTestId("commons-card")).toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         
     })
 
@@ -632,9 +652,13 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
         
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        
         await waitFor(() => {
             expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         });        
+        
+        await new Promise((r) => setTimeout(r, 100));
         
         expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
@@ -666,9 +690,13 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
         
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        
         await waitFor(() => {
             expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         });        
+        
+        await new Promise((r) => setTimeout(r, 100));
         
         expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -525,5 +525,154 @@ describe("PlayPage tests", () => {
         
     })
 
+    test("user has entered nonexistant the commons (one commons created)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+ 	axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 5,
+                name: "Sample Commons"
+            }
+        ]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => {
+            expect(screen.getByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).toBeInTheDocument();
+        });        
+        
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+  
+    })
+    
+    test("user has entered nonexistant the commons (two commons created)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+ 	axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 5,
+                name: "Sample Commons"
+            },
+            {
+                id: 6,
+                name: "Other Commons"
+            }
+        ]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => {
+            expect(screen.getByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).toBeInTheDocument();
+        });        
+        
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        
+    })
+    
+    test("user has entered nonexistant the commons (no commons created)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+ 	axiosMock.onGet("/api/commons/all").reply(200, []);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => {
+            expect(screen.getByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).toBeInTheDocument();
+        });        
+        
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        
+    })
+    
+    test("user has entered joined and extant commons (one commons created)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 1,
+                name: "Sample Commons"
+            }
+        ]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => {
+            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        });        
+        
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        
+    })
+    
+    test("user has entered joined and extant commons (two commons created)", async () => {
+        
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/commons/all").reply(200, [
+            {
+                id: 1,
+                name: "Sample Commons"
+            },
+            {
+                id: 6,
+                name: "Other Commons"
+            }
+        ]);
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlayPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+        
+        await waitFor(() => {
+            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        });        
+        
+        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
+        
+    })
    
 });

--- a/frontend/src/tests/pages/PlayPage.test.js
+++ b/frontend/src/tests/pages/PlayPage.test.js
@@ -384,7 +384,7 @@ describe("PlayPage tests", () => {
 
         expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
         expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
 
     })
     
@@ -432,7 +432,7 @@ describe("PlayPage tests", () => {
 
         expect(screen.getByText("Whoa there, parder! You ain't a part of this commons!")).toBeInTheDocument();   
         expect(screen.queryByTestId("commons-card")).not.toBeInTheDocument();    
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
 	
     })
     
@@ -469,7 +469,7 @@ describe("PlayPage tests", () => {
         );
         
         await waitFor(() => {
-            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+            expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         });   
 
         await waitFor(() => {
@@ -485,7 +485,7 @@ describe("PlayPage tests", () => {
         
         expect(screen.getByTestId("commons-card")).toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         
     })
 
@@ -526,7 +526,7 @@ describe("PlayPage tests", () => {
         );
 
         await waitFor(() => {
-            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+            expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         });   
 
         await waitFor(() => {
@@ -541,7 +541,7 @@ describe("PlayPage tests", () => {
         
         expect(screen.getByTestId("commons-card")).toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         
     })
 
@@ -567,7 +567,7 @@ describe("PlayPage tests", () => {
         );
         
         await waitFor(() => {
-            expect(screen.getByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).toBeInTheDocument();
+            expect(screen.getByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).toBeInTheDocument();
         });        
         
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
@@ -600,7 +600,7 @@ describe("PlayPage tests", () => {
         );
         
         await waitFor(() => {
-            expect(screen.getByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).toBeInTheDocument();
+            expect(screen.getByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).toBeInTheDocument();
         });        
         
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
@@ -624,7 +624,7 @@ describe("PlayPage tests", () => {
         );
         
         await waitFor(() => {
-            expect(screen.getByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).toBeInTheDocument();
+            expect(screen.getByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).toBeInTheDocument();
         });        
         
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
@@ -652,15 +652,15 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
         
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         
         await waitFor(() => {
-            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+            expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         });        
         
         await new Promise((r) => setTimeout(r, 100));
         
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
         
     })
@@ -690,15 +690,15 @@ describe("PlayPage tests", () => {
             </QueryClientProvider>
         );
         
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         
         await waitFor(() => {
-            expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+            expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         });        
         
         await new Promise((r) => setTimeout(r, 100));
         
-        expect(screen.queryByText("What are you doing here, friendo? This commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
+        expect(screen.queryByText("What are you doing here, friendo? This here commons don't exist! You best be headin' back.")).not.toBeInTheDocument();
         expect(screen.queryByText("Whoa there, parder! You ain't a part of this commons!")).not.toBeInTheDocument();
         
     })


### PR DESCRIPTION
## Overview
In this PR, when a user navigates to a commons that does not exist, a message is shown indicating this fact. As an additional small one line fix, commons chat should no longer be available to regular users who are not part of a commons. Chat should also be unavailable to commons that do not exist.

## Screenshots
![proj-notexist](https://github.com/ucsb-cs156-s24/proj-happycows-s24-4pm-6/assets/165851243/13aa0bfd-7efd-4851-a0a0-d017eb65e3dd)

## Validation
Go to the test deployment and navigate to a commons that doesn't exist (eg: /play/# where # is the id of a nonexistent commons). Along with a message, the chat windows should also be absent. To test a regular user's access to chat, login as a non admin user and navigate to an un-joined commons. The chat windows should be absent.
https://project-ok-at-computers-dev.dokku-06.cs.ucsb.edu/

## Tests
- [ ] Backend Unit tests (`mvn test`) pass
- [ ] Backend Test coverage (`mvn test jacoco:report`) 100%
- [ ] Backend Mutation tests (`mvn test pitest:mutationCoverage`) 100% 
- [ ] Frontend Unit tests (`npm test`) pass
- [ ] Frontend Test coverage (`npm run coverage`) 100%
- [ ] Frontend Mutation tests (`npx stryker run`) 100% 
- [ ] Frontend Linting (`npx eslint --fix src`) 

## Linked Issues
Closes #31 
Closes #55 
